### PR TITLE
Add progressive chunk order strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-HELP.md
 target/
 !.mvn/wrapper/maven-wrapper.jar
 **/src/main/**/target/

--- a/Readme.md
+++ b/Readme.md
@@ -252,7 +252,6 @@ STRATEGY: SELL_LATER
 - **SELL_LATER** → Useful for **longer-term holds** instead of auto-selling.
 ---
 
-
 ## Chunked Buy and Sell Orders
 
 The bot now supports placing buy and sell orders in smaller parts (called "chunks"). This helps avoid problems like sudden price changes when trading large amounts.
@@ -282,6 +281,72 @@ When you use the `CHUNKED` setting:
 * Adapts to how actively a coin is being traded.
 * Makes it easier to manage and track each trade.
 
+---
+
+### CHUNKED_PROGRESSIVE Strategy
+
+This advanced execution strategy builds upon `CHUNKED` by reacting dynamically to real-time market conditions. It also supports multiple entries, margin-split investments, calculated leverage, and multiple take-profit levels.
+
+To enable:
+
+```properties
+app.bot.execution.strategy=CHUNKED_PROGRESSIVE
+```
+
+#### How It Works
+
+* The bot calculates **average quote volume** using recent 5-minute candlesticks.
+* Based on this liquidity, it dynamically sets the **number of chunks**:
+
+  * Higher liquidity → more chunks.
+  * Lower liquidity → fewer chunks.
+* Before placing each chunk, the bot ensures:
+
+  * The **price is within the signal's entry range**.
+  * The market shows a **short-term bullish trend** (based on recent price movements).
+* For each chunk:
+
+  * It uses a **fixed portion of the total margin** (e.g., 5% of portfolio split evenly).
+
+  * It calculates **leverage** using the formula:
+
+    ```
+    leverage = entryPrice / (entryPrice - stopLoss)
+    ```
+
+  * It assigns a specific **take-profit level** based on chunk index.
+* Each chunk is sold **independently** once its target profit price is reached.
+
+#### Signal Example
+
+```
+NKNBTC
+ENTRY: 0.00000260 - 0.00000290
+TP1: 0.00000315
+TP2: 0.00000360
+TP3: 0.00000432
+TP4: 0.00000486
+TP5: 0.00000550
+TP6: 0.00000666
+TP7: 0.00000741
+STOP: Close weekly below 0.00000240
+```
+
+In this case:
+
+* The bot averages the entry range (e.g., midpoint of 0.00000260 and 0.00000290).
+* Calculates leverage using that midpoint and the stop price (e.g., 0.00000275 / (0.00000275 - 0.00000240)).
+* Distributes investment and assigns a corresponding take-profit (TP1–TP7) per chunk.
+
+#### Advantages
+
+* Reacts to live market signals for smarter trade timing.
+* Dynamically adjusts chunking based on market liquidity.
+* Calculates leverage based on real risk (entry vs. stop).
+* Supports multiple TP levels for staggered profit-taking.
+
+---
+
 ### Switch Back to Default
 
 If you want the bot to place just one buy and one sell order per signal, change the setting back to:
@@ -289,6 +354,8 @@ If you want the bot to place just one buy and one sell order per signal, change 
 ```properties
 app.bot.execution.strategy=DEFAULT
 ```
+
+---
 
 ## Test Coverage
 

--- a/src/main/java/com/ozgen/telegrambinancebot/adapters/events/IncomingProgressiveChunkedTradingSignalEventListener.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/adapters/events/IncomingProgressiveChunkedTradingSignalEventListener.java
@@ -1,0 +1,23 @@
+package com.ozgen.telegrambinancebot.adapters.events;
+
+import com.ozgen.telegrambinancebot.manager.binance.BinanceTradingSignalManager;
+import com.ozgen.telegrambinancebot.model.events.IncomingProgressiveChunkedTradingSignalEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class IncomingProgressiveChunkedTradingSignalEventListener implements ApplicationListener<IncomingProgressiveChunkedTradingSignalEvent> {
+
+    private final BinanceTradingSignalManager binanceTradingSignalManager;
+
+    @Override
+    public void onApplicationEvent(@NotNull IncomingProgressiveChunkedTradingSignalEvent event) {
+        log.info("new IncomingProgressiveChunkedTradingSignalEvent consumed. event : {}", event);
+        this.binanceTradingSignalManager.processIncomingProgressiveChunkedTradingSignalEvent(event);
+    }
+}

--- a/src/main/java/com/ozgen/telegrambinancebot/adapters/events/NewChunkedBuyOrderEventListener.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/adapters/events/NewChunkedBuyOrderEventListener.java
@@ -1,23 +1,24 @@
 package com.ozgen.telegrambinancebot.adapters.events;
 
 import com.ozgen.telegrambinancebot.manager.binance.BinanceChunkBuyOrderManager;
-import com.ozgen.telegrambinancebot.model.events.NewChunkedBuyExecutionEvent;
+import com.ozgen.telegrambinancebot.model.events.NewChunkedBuyOrderEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class NewChunkedBuyExecutionEventListener implements ApplicationListener<NewChunkedBuyExecutionEvent> {
-
+public class NewChunkedBuyOrderEventListener implements ApplicationListener<NewChunkedBuyOrderEvent> {
 
     private final BinanceChunkBuyOrderManager binanceChunkBuyOrderManager;
 
+    //todo write unit test for this
     @Override
-    public void onApplicationEvent(NewChunkedBuyExecutionEvent event) {
-        log.info("new NewChunkedBuyExecutionEvent consumed. event : {}", event);
+    public void onApplicationEvent(@NotNull NewChunkedBuyOrderEvent event) {
+        log.info("new NewChunkedBuyOrderEvent consumed. event : {}", event);
         this.binanceChunkBuyOrderManager.handleChunkedBuyEvent(event);
     }
 }

--- a/src/main/java/com/ozgen/telegrambinancebot/adapters/events/NewChunkedBuyOrderEventListener.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/adapters/events/NewChunkedBuyOrderEventListener.java
@@ -15,7 +15,6 @@ public class NewChunkedBuyOrderEventListener implements ApplicationListener<NewC
 
     private final BinanceChunkBuyOrderManager binanceChunkBuyOrderManager;
 
-    //todo write unit test for this
     @Override
     public void onApplicationEvent(@NotNull NewChunkedBuyOrderEvent event) {
         log.info("new NewChunkedBuyOrderEvent consumed. event : {}", event);

--- a/src/main/java/com/ozgen/telegrambinancebot/adapters/events/NewProgressiveChunkSellOrderEventListener.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/adapters/events/NewProgressiveChunkSellOrderEventListener.java
@@ -1,0 +1,23 @@
+package com.ozgen.telegrambinancebot.adapters.events;
+
+import com.ozgen.telegrambinancebot.manager.binance.BinanceProgressiveChunkedSellOrderManager;
+import com.ozgen.telegrambinancebot.model.events.NewProgressiveChunkedSellOrderEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NewProgressiveChunkSellOrderEventListener implements ApplicationListener<NewProgressiveChunkedSellOrderEvent> {
+
+    private final BinanceProgressiveChunkedSellOrderManager binanceProgressiveChunkedSellOrderManager;
+
+    @Override
+    public void onApplicationEvent(@NotNull NewProgressiveChunkedSellOrderEvent event) {
+        log.info("new NewProgressiveChunkedSellOrderEvent consumed. event : {}", event);
+        this.binanceProgressiveChunkedSellOrderManager.onNewSellProgressiveChunkOrderEvent(event);
+    }
+}

--- a/src/main/java/com/ozgen/telegrambinancebot/adapters/events/NewProgressiveChunkedBuyOrderEventListener.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/adapters/events/NewProgressiveChunkedBuyOrderEventListener.java
@@ -1,0 +1,23 @@
+package com.ozgen.telegrambinancebot.adapters.events;
+
+import com.ozgen.telegrambinancebot.manager.binance.BinanceProgressiveChunkedBuyOrderManager;
+import com.ozgen.telegrambinancebot.model.events.NewProgressiveChunkedBuyOrderEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NewProgressiveChunkedBuyOrderEventListener implements ApplicationListener<NewProgressiveChunkedBuyOrderEvent> {
+
+    private final BinanceProgressiveChunkedBuyOrderManager binanceProgressiveChunkedBuyOrderManager;
+
+    @Override
+    public void onApplicationEvent(@NotNull NewProgressiveChunkedBuyOrderEvent event) {
+        log.info("new NewProgressiveChunkedBuyOrderEvent consumed. event : {}", event);
+        this.binanceProgressiveChunkedBuyOrderManager.handleProgressiveChunkedBuy(event);
+    }
+}

--- a/src/main/java/com/ozgen/telegrambinancebot/adapters/repository/ChunkOrderRepository.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/adapters/repository/ChunkOrderRepository.java
@@ -1,5 +1,6 @@
 package com.ozgen.telegrambinancebot.adapters.repository;
 
+import com.ozgen.telegrambinancebot.model.ExecutionStrategy;
 import com.ozgen.telegrambinancebot.model.bot.ChunkOrder;
 import com.ozgen.telegrambinancebot.model.bot.OrderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,5 +13,10 @@ import java.util.List;
 public interface ChunkOrderRepository extends JpaRepository<ChunkOrder, String> {
 
     List<ChunkOrder> findAllByStatus(OrderStatus orderStatus);
-    List<ChunkOrder> findAllByCreatedAtAfterAndStatusIn(Date date, List<OrderStatus> orderStatus);
+    List<ChunkOrder> findAllByCreatedAtAfterAndStatusInAndTradingSignal_ExecutionStrategy(
+            Date date,
+            List<OrderStatus> statuses,
+            ExecutionStrategy executionStrategy
+    );
+    List<ChunkOrder> findAllByTradingSignalIdAndAndStatusIn(String tradingSignalId, List<OrderStatus> statuses);
 }

--- a/src/main/java/com/ozgen/telegrambinancebot/adapters/repository/ChunkOrderRepository.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/adapters/repository/ChunkOrderRepository.java
@@ -18,5 +18,5 @@ public interface ChunkOrderRepository extends JpaRepository<ChunkOrder, String> 
             List<OrderStatus> statuses,
             ExecutionStrategy executionStrategy
     );
-    List<ChunkOrder> findAllByTradingSignalIdAndAndStatusIn(String tradingSignalId, List<OrderStatus> statuses);
+    List<ChunkOrder> findAllByTradingSignalIdAndStatusIn(String tradingSignalId, List<OrderStatus> statuses);
 }

--- a/src/main/java/com/ozgen/telegrambinancebot/configuration/properties/AppConfiguration.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/configuration/properties/AppConfiguration.java
@@ -12,6 +12,6 @@ import org.springframework.context.annotation.Configuration;
 @Setter
 public class AppConfiguration {
 
-    private ExecutionStrategy executionStrategy;
+    private ExecutionStrategy strategy;
     private double minQuoteVolume;
 }

--- a/src/main/java/com/ozgen/telegrambinancebot/manager/binance/BinanceHelper.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/manager/binance/BinanceHelper.java
@@ -125,5 +125,4 @@ public class BinanceHelper {
         Double btcAmount = GenericParser.getAssetFromSymbol(assets, this.botConfiguration.getCurrency());
         return btcAmount >= btcInvestAmount;
     }
-
 }

--- a/src/main/java/com/ozgen/telegrambinancebot/manager/binance/BinanceProgressiveChunkedBuyOrderManager.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/manager/binance/BinanceProgressiveChunkedBuyOrderManager.java
@@ -1,0 +1,215 @@
+package com.ozgen.telegrambinancebot.manager.binance;
+
+import com.ozgen.telegrambinancebot.configuration.properties.AppConfiguration;
+import com.ozgen.telegrambinancebot.configuration.properties.BotConfiguration;
+import com.ozgen.telegrambinancebot.model.binance.IntervalType;
+import com.ozgen.telegrambinancebot.model.binance.KlineData;
+import com.ozgen.telegrambinancebot.model.binance.TickerData;
+import com.ozgen.telegrambinancebot.model.bot.ChunkOrder;
+import com.ozgen.telegrambinancebot.model.bot.OrderStatus;
+import com.ozgen.telegrambinancebot.model.events.ErrorEvent;
+import com.ozgen.telegrambinancebot.model.events.InfoEvent;
+import com.ozgen.telegrambinancebot.model.events.NewProgressiveChunkedBuyOrderEvent;
+import com.ozgen.telegrambinancebot.model.events.NewProgressiveChunkedSellOrderEvent;
+import com.ozgen.telegrambinancebot.model.telegram.TradingSignal;
+import com.ozgen.telegrambinancebot.service.BotOrderService;
+import com.ozgen.telegrambinancebot.utils.SyncUtil;
+import com.ozgen.telegrambinancebot.utils.parser.GenericParser;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class BinanceProgressiveChunkedBuyOrderManager {
+
+    private final BinanceApiManager binanceApiManager;
+    private final BotOrderService buyChunkOrderService;
+    private final BinanceHelper binanceHelper;
+    private final ApplicationEventPublisher publisher;
+    private final BotConfiguration botConfiguration;
+    private final AppConfiguration appConfiguration;
+
+    @EventListener
+    @Transactional
+    public void handleProgressiveChunkedBuy(NewProgressiveChunkedBuyOrderEvent event) {
+        TradingSignal signal = event.getTradingSignal();
+        TickerData ticker = event.getTickerData();
+        String symbol = signal.getSymbol();
+
+        try {
+            double currentPrice = GenericParser.getDouble(ticker.getLastPrice()).orElseThrow();
+
+            List<KlineData> klines = binanceApiManager.getListOfKlineData(symbol, IntervalType.FIVE_MINUTES);
+            double avgQuoteVolume = klines.stream()
+                    .mapToDouble(KlineData::getQuoteAssetVolume)
+                    .average()
+                    .orElse(0.0);
+
+            if (avgQuoteVolume < appConfiguration.getMinQuoteVolume()) {
+                log.warn("Low liquidity for {} (avg quote volume: {}). Skipping.", symbol, avgQuoteVolume);
+                return;
+            }
+
+            int maxChunks = this.binanceHelper.calculateDynamicChunkCount(avgQuoteVolume);
+
+            List<ChunkOrder> executedChunks = buyChunkOrderService
+                    .getChunksBySignalAndStatuses(signal.getId(), List.of(OrderStatus.BUY_EXECUTED));
+
+            if (executedChunks.size() >= maxChunks) {
+                log.info("All chunks already placed for signal {}", signal.getId());
+                return;
+            }
+
+            if (shouldPlaceNextChunk(signal, currentPrice, klines)) {
+                log.info("Market looks good. Placing next chunk for {}", symbol);
+                placeNextChunk(signal, currentPrice, executedChunks.size(), maxChunks);
+            } else {
+                log.info("Conditions not favorable yet for {}", symbol);
+            }
+
+        } catch (Exception e) {
+            log.error("Error in progressive chunk buy for {}: {}", signal.getSymbol(), e.getMessage(), e);
+            publisher.publishEvent(new ErrorEvent(this, e));
+        }
+    }
+
+    public void processFailedProgressiveBuyChunks() {
+        Date searchDate = binanceHelper.getSearchDate();
+        List<OrderStatus> statuses = List.of(OrderStatus.BUY_FAILED);
+        List<ChunkOrder> orders = buyChunkOrderService.getBuyProgressiveChunksByStatusesAndDate(
+                statuses, searchDate);
+
+        log.info("Found {} executed progressive buy chunks", orders.size());
+        orders.forEach(order -> {
+            if (shouldRetryFailedChunk(order)) {
+                publisher.publishEvent(new NewProgressiveChunkedSellOrderEvent(this, order));
+            }
+        });
+    }
+
+    public void processExecutedProgressiveBuyChunks() {
+        Date searchDate = binanceHelper.getSearchDate();
+        List<OrderStatus> statuses = List.of(OrderStatus.BUY_EXECUTED);
+        List<ChunkOrder> orders = buyChunkOrderService.getBuyProgressiveChunksByStatusesAndDate(
+                statuses, searchDate);
+
+        log.info("Found {} executed progressive buy chunks", orders.size());
+        orders.forEach(order -> {
+            if (shouldTriggerNextChunk(order)) {
+                publisher.publishEvent(new NewProgressiveChunkedSellOrderEvent(this, order));
+            }
+        });
+    }
+
+    public boolean shouldTriggerNextChunk(ChunkOrder chunkOrder) {
+        TradingSignal signal = chunkOrder.getTradingSignal();
+        String symbol = chunkOrder.getSymbol();
+
+        // If already the last chunk, don't trigger more
+        if (chunkOrder.getChunkIndex() >= chunkOrder.getTotalChunkCount() - 1) {
+            log.info("Chunk {} is the last one. No further chunks to trigger.", chunkOrder.getId());
+            return false;
+        }
+
+        try {
+            double currentPrice = GenericParser.getDouble(
+                    binanceApiManager.getTickerPrice24(symbol).getLastPrice()
+            ).orElseThrow();
+
+            double entryStart = GenericParser.getDouble(signal.getEntryStart()).orElse(0.0);
+            double entryEnd = GenericParser.getDouble(signal.getEntryEnd()).orElse(Double.MAX_VALUE);
+
+            // Trigger next chunk if price is still in entry zone
+            boolean inEntryZone = currentPrice >= entryStart && currentPrice <= entryEnd;
+
+            if (!inEntryZone) {
+                log.info("Current price {} not in entry range ({} - {}) for symbol {}",
+                        currentPrice, entryStart, entryEnd, symbol);
+            }
+
+            return inEntryZone;
+        } catch (Exception e) {
+            log.error("Failed to determine if next chunk should be triggered for chunk {}: {}", chunkOrder.getId(), e.getMessage(), e);
+            return false;
+        }
+    }
+
+    public boolean shouldRetryFailedChunk(ChunkOrder chunkOrder) {
+        TradingSignal signal = chunkOrder.getTradingSignal();
+        String symbol = chunkOrder.getSymbol();
+
+        try {
+            double currentPrice = GenericParser.getDouble(
+                    binanceApiManager.getTickerPrice24(symbol).getLastPrice()
+            ).orElseThrow();
+
+            double entryStart = GenericParser.getDouble(signal.getEntryStart()).orElse(0.0);
+            double entryEnd = GenericParser.getDouble(signal.getEntryEnd()).orElse(Double.MAX_VALUE);
+
+            boolean inEntryZone = currentPrice >= entryStart && currentPrice <= entryEnd;
+
+            if (!inEntryZone) {
+                log.info("Retry skipped for chunk {}: price {} out of entry range ({} - {})",
+                        chunkOrder.getId(), currentPrice, entryStart, entryEnd);
+            }
+
+            return inEntryZone;
+        } catch (Exception e) {
+            log.error("Error while checking retry condition for chunk {}: {}", chunkOrder.getId(), e.getMessage(), e);
+            return false;
+        }
+    }
+
+    private boolean shouldPlaceNextChunk(TradingSignal signal, double currentPrice, List<KlineData> klines) {
+        double entryStart = GenericParser.getDouble(signal.getEntryStart()).orElseThrow();
+        double entryEnd = GenericParser.getDouble(signal.getEntryEnd()).orElseThrow();
+
+        boolean inEntryRange = currentPrice >= entryEnd && currentPrice <= entryStart;
+        boolean shortTermBullish = binanceHelper.isShortTermBullish(klines);
+
+        return inEntryRange && shortTermBullish;
+    }
+
+    private void placeNextChunk(TradingSignal signal, double currentPrice, int chunkIndex, int maxChunks) {
+        double stopLoss = GenericParser.getDouble(signal.getStopLoss()).orElseThrow();
+        double leverage = currentPrice / (currentPrice - stopLoss);
+
+        double totalInvestment = botConfiguration.getAmount();
+        double investPerChunk = totalInvestment / maxChunks;
+        double coinAmount = investPerChunk / currentPrice;
+
+        ChunkOrder chunkOrder = new ChunkOrder();
+        chunkOrder.setSymbol(signal.getSymbol());
+        chunkOrder.setChunkIndex(chunkIndex);
+        chunkOrder.setTotalChunkCount(maxChunks);
+        chunkOrder.setBuyCoinAmount(coinAmount);
+        chunkOrder.setBuyPrice(currentPrice);
+        chunkOrder.setStopLoss(stopLoss);
+        chunkOrder.setTradingSignal(signal);
+        chunkOrder.setEntryPoint(currentPrice);
+        chunkOrder.setLeverage(leverage);
+        chunkOrder.setTakeProfitIndex(chunkIndex % signal.getTakeProfits().size());
+        chunkOrder.setTakeProfitAllocation(100 / maxChunks);
+
+        try {
+            binanceApiManager.newOrder(signal.getSymbol(), currentPrice, coinAmount);
+            chunkOrder.setStatus(OrderStatus.BUY_EXECUTED);
+        } catch (Exception e) {
+            chunkOrder.setStatus(OrderStatus.BUY_FAILED);
+            publisher.publishEvent(new ErrorEvent(this, e));
+        }
+
+        ChunkOrder saved = buyChunkOrderService.saveChunkOrder(chunkOrder);
+        publisher.publishEvent(new InfoEvent(this, "Saved progressive BuyChunkOrder: " + saved));
+        publisher.publishEvent(new NewProgressiveChunkedSellOrderEvent(this, chunkOrder));
+        SyncUtil.pauseBetweenOperations();
+    }
+}

--- a/src/main/java/com/ozgen/telegrambinancebot/manager/binance/BinanceProgressiveChunkedSellOrderManager.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/manager/binance/BinanceProgressiveChunkedSellOrderManager.java
@@ -15,7 +15,6 @@ import com.ozgen.telegrambinancebot.utils.parser.GenericParser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
@@ -32,7 +31,6 @@ public class BinanceProgressiveChunkedSellOrderManager {
     private final BotConfiguration botConfiguration;
     private final BinanceHelper binanceHelper;
 
-    @EventListener
     public void onNewSellProgressiveChunkOrderEvent(NewProgressiveChunkedSellOrderEvent event) {
         processChunkOrder(event.getChunkOrder());
     }
@@ -40,12 +38,12 @@ public class BinanceProgressiveChunkedSellOrderManager {
     public void processSellChunkOrders() {
         Date searchDate = this.binanceHelper.getSearchDate();
         List<OrderStatus> statuses = List.of(OrderStatus.SELL_PENDING_RETRY, OrderStatus.SELL_FAILED);
-        List<ChunkOrder> orders = botOrderService.getBuyProgressiveChunksByStatusesAndDate(statuses, searchDate);
+        List<ChunkOrder> orders = botOrderService.getProgressiveChunksByStatusesAndDate(statuses, searchDate);
         log.info("Found {} progressive sell candidates", orders.size());
         orders.forEach(this::processChunkOrder);
     }
 
-    private void processChunkOrder(ChunkOrder chunkOrder) {
+    protected void processChunkOrder(ChunkOrder chunkOrder) {
         TradingSignal signal = chunkOrder.getTradingSignal();
         String symbol = chunkOrder.getSymbol();
 

--- a/src/main/java/com/ozgen/telegrambinancebot/manager/binance/BinanceProgressiveChunkedSellOrderManager.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/manager/binance/BinanceProgressiveChunkedSellOrderManager.java
@@ -1,0 +1,124 @@
+package com.ozgen.telegrambinancebot.manager.binance;
+
+import com.ozgen.telegrambinancebot.configuration.properties.BotConfiguration;
+import com.ozgen.telegrambinancebot.model.TradingStrategy;
+import com.ozgen.telegrambinancebot.model.binance.AssetBalance;
+import com.ozgen.telegrambinancebot.model.bot.ChunkOrder;
+import com.ozgen.telegrambinancebot.model.bot.OrderStatus;
+import com.ozgen.telegrambinancebot.model.events.ErrorEvent;
+import com.ozgen.telegrambinancebot.model.events.InfoEvent;
+import com.ozgen.telegrambinancebot.model.events.NewProgressiveChunkedSellOrderEvent;
+import com.ozgen.telegrambinancebot.model.telegram.TradingSignal;
+import com.ozgen.telegrambinancebot.service.BotOrderService;
+import com.ozgen.telegrambinancebot.utils.PriceCalculator;
+import com.ozgen.telegrambinancebot.utils.parser.GenericParser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class BinanceProgressiveChunkedSellOrderManager {
+
+    private final BinanceApiManager binanceApiManager;
+    private final BotOrderService botOrderService;
+    private final ApplicationEventPublisher publisher;
+    private final BotConfiguration botConfiguration;
+    private final BinanceHelper binanceHelper;
+
+    @EventListener
+    public void onNewSellProgressiveChunkOrderEvent(NewProgressiveChunkedSellOrderEvent event) {
+        processChunkOrder(event.getChunkOrder());
+    }
+
+    public void processSellChunkOrders() {
+        Date searchDate = this.binanceHelper.getSearchDate();
+        List<OrderStatus> statuses = List.of(OrderStatus.SELL_PENDING_RETRY, OrderStatus.SELL_FAILED);
+        List<ChunkOrder> orders = botOrderService.getBuyProgressiveChunksByStatusesAndDate(statuses, searchDate);
+        log.info("Found {} progressive sell candidates", orders.size());
+        orders.forEach(this::processChunkOrder);
+    }
+
+    private void processChunkOrder(ChunkOrder chunkOrder) {
+        TradingSignal signal = chunkOrder.getTradingSignal();
+        String symbol = chunkOrder.getSymbol();
+
+        try {
+            double currentPrice = GenericParser.getDouble(
+                    binanceApiManager.getTickerPrice24(symbol).getLastPrice()
+            ).orElseThrow();
+
+            List<String> takeProfits = signal.getTakeProfits();
+            double tpPrice;
+
+            if (chunkOrder.getTakeProfitIndex() >= 0 && chunkOrder.getTakeProfitIndex() < takeProfits.size()) {
+                tpPrice = GenericParser.getDouble(takeProfits.get(chunkOrder.getTakeProfitIndex())).orElse(0.0);
+            } else {
+                tpPrice = PriceCalculator.calculateCoinPriceInc(
+                        chunkOrder.getBuyPrice(), botConfiguration.getProfitPercentage()
+                );
+            }
+
+            boolean shouldSell = currentPrice >= tpPrice || signal.getStrategy() == TradingStrategy.DEFAULT;
+
+            if (shouldSell) {
+                double stopLoss = GenericParser.getDouble(signal.getStopLoss()).orElse(0.0);
+                List<AssetBalance> assets = binanceHelper.getUserAssets();
+
+                double sellAmount = binanceHelper.calculateSellAmount(assets, chunkOrder);
+                if (sellAmount <= 0) {
+                    log.warn("No available balance for chunk {}. Skipping sell.", chunkOrder.getId());
+                    return;
+                }
+
+                chunkOrder.setSellCoinAmount(sellAmount);
+
+                binanceApiManager.newOrderWithStopLoss(symbol, tpPrice, sellAmount, stopLoss);
+
+                chunkOrder.setSellPrice(tpPrice);
+                chunkOrder.setStopLoss(stopLoss);
+                chunkOrder.setStatus(OrderStatus.SELL_EXECUTED);
+                publisher.publishEvent(new InfoEvent(this, "Progressive sell executed: " + chunkOrder));
+                log.info("Executed progressive sell for chunk {}", chunkOrder.getId());
+            } else {
+                chunkOrder.setStatus(OrderStatus.SELL_PENDING_RETRY);
+                log.info("Chunk {} not sold. Current price ({}) below TP ({})",
+                        chunkOrder.getId(), currentPrice, tpPrice);
+            }
+
+        } catch (Exception e) {
+            chunkOrder.setStatus(OrderStatus.SELL_FAILED);
+            publisher.publishEvent(new ErrorEvent(this, e));
+            log.error("Error executing progressive sell for chunk {}: {}", chunkOrder.getId(), e.getMessage(), e);
+        }
+
+        botOrderService.saveChunkOrder(chunkOrder);
+    }
+
+    public void retryPendingChunks() {
+        List<ChunkOrder> pending = botOrderService.getBuyChunksByStatus(OrderStatus.SELL_PENDING_RETRY);
+
+        for (ChunkOrder chunk : pending) {
+            try {
+                double price = GenericParser.getDouble(
+                        binanceApiManager.getTickerPrice24(chunk.getSymbol()).getLastPrice()
+                ).orElseThrow();
+
+                if (price > chunk.getBuyPrice()) {
+                    log.info("Retrying progressive chunk {} due to rising price", chunk.getId());
+                    publisher.publishEvent(new NewProgressiveChunkedSellOrderEvent(this, chunk));
+                } else {
+                    log.info("Progressive chunk {} still not profitable. Skipping.", chunk.getId());
+                }
+            } catch (Exception e) {
+                log.error("Error retrying progressive chunk {}: {}", chunk.getId(), e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/ozgen/telegrambinancebot/manager/binance/BinanceTradingSignalManager.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/manager/binance/BinanceTradingSignalManager.java
@@ -3,9 +3,11 @@ package com.ozgen.telegrambinancebot.manager.binance;
 import com.ozgen.telegrambinancebot.model.binance.TickerData;
 import com.ozgen.telegrambinancebot.model.events.ErrorEvent;
 import com.ozgen.telegrambinancebot.model.events.IncomingChunkedTradingSignalEvent;
+import com.ozgen.telegrambinancebot.model.events.IncomingProgressiveChunkedTradingSignalEvent;
 import com.ozgen.telegrambinancebot.model.events.IncomingTradingSignalEvent;
 import com.ozgen.telegrambinancebot.model.events.NewBuyOrderEvent;
-import com.ozgen.telegrambinancebot.model.events.NewChunkedBuyExecutionEvent;
+import com.ozgen.telegrambinancebot.model.events.NewChunkedBuyOrderEvent;
+import com.ozgen.telegrambinancebot.model.events.NewProgressiveChunkedBuyOrderEvent;
 import com.ozgen.telegrambinancebot.model.telegram.TradingSignal;
 import com.ozgen.telegrambinancebot.utils.validators.TradingSignalValidator;
 import lombok.RequiredArgsConstructor;
@@ -71,11 +73,39 @@ public class BinanceTradingSignalManager {
 
         if (availableToBuy) {
             log.info("Chunked strategy active: scheduling chunked buy orders for {}", symbol);
-            this.publisher.publishEvent(new NewChunkedBuyExecutionEvent(this, tradingSignal, tickerPrice24));
+            this.publisher.publishEvent(new NewChunkedBuyOrderEvent(this, tradingSignal, tickerPrice24));
         } else {
             log.info("Symbol {} is not available to buy under chunked strategy", symbol);
         }
     }
+
+    public void processIncomingProgressiveChunkedTradingSignalEvent(IncomingProgressiveChunkedTradingSignalEvent event) {
+        TradingSignal tradingSignal = event.getTradingSignal();
+        String symbol = tradingSignal.getSymbol();
+
+        log.info("Processing incoming CHUNKED_PROGRESSIVE trading signal for symbol: {}", symbol);
+
+        TickerData tickerPrice24;
+        try {
+            tickerPrice24 = this.binanceApiManager.getTickerPrice24(symbol);
+            log.info("Fetched ticker price for symbol {}: {}", symbol, tickerPrice24);
+        } catch (Exception e) {
+            log.error("Error occurred while fetching ticker price for symbol {}: {}", symbol, e.getMessage(), e);
+            this.processException(e);
+            throw new RuntimeException("Error fetching ticker price", e);
+        }
+
+        boolean availableToBuy = TradingSignalValidator.isAvailableToBuy(tickerPrice24, tradingSignal);
+        log.info("Availability to buy for symbol {}: {}", symbol, availableToBuy);
+
+        if (availableToBuy) {
+            log.info("Progressive chunk strategy active: publishing event for {}", symbol);
+            this.publisher.publishEvent(new NewProgressiveChunkedBuyOrderEvent(this, tradingSignal, tickerPrice24));
+        } else {
+            log.info("Symbol {} is not available to buy under progressive chunk strategy", symbol);
+        }
+    }
+
 
     private void processException(Exception e) {
         ErrorEvent errorEvent = new ErrorEvent(this, e);

--- a/src/main/java/com/ozgen/telegrambinancebot/manager/telegram/TelegramMessageManager.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/manager/telegram/TelegramMessageManager.java
@@ -4,6 +4,7 @@ import com.ozgen.telegrambinancebot.configuration.properties.AppConfiguration;
 import com.ozgen.telegrambinancebot.model.ExecutionStrategy;
 import com.ozgen.telegrambinancebot.model.ProcessStatus;
 import com.ozgen.telegrambinancebot.model.events.IncomingChunkedTradingSignalEvent;
+import com.ozgen.telegrambinancebot.model.events.IncomingProgressiveChunkedTradingSignalEvent;
 import com.ozgen.telegrambinancebot.model.events.IncomingTradingSignalEvent;
 import com.ozgen.telegrambinancebot.model.telegram.TradingSignal;
 import com.ozgen.telegrambinancebot.service.TradingSignalService;
@@ -39,12 +40,15 @@ public class TelegramMessageManager {
             return FAILED_MESSAGE;
         }
         tradingSignal.setIsProcessed(ProcessStatus.INIT);
-        tradingSignal.setExecutionStrategy(appConfiguration.getExecutionStrategy());
+        tradingSignal.setExecutionStrategy(appConfiguration.getStrategy());
 
         TradingSignal saved = this.tradingSignalService.saveTradingSignal(tradingSignal);
         if (saved.getExecutionStrategy() == ExecutionStrategy.CHUNKED) {
             log.info("Dispatching IncomingChunkedTradingSignalEvent for {}", saved.getSymbol());
             this.publisher.publishEvent(new IncomingChunkedTradingSignalEvent(this, saved));
+        } else if (saved.getExecutionStrategy() == ExecutionStrategy.CHUNKED_PROGRESSIVE) {
+            log.info("Dispatching IncomingProgressiveChunkedTradingSignalEvent for {}", saved.getSymbol());
+            this.publisher.publishEvent(new IncomingProgressiveChunkedTradingSignalEvent(this, saved));
         } else {
             log.info("Dispatching IncomingTradingSignalEvent for {}", saved.getSymbol());
             this.publisher.publishEvent(new IncomingTradingSignalEvent(this, saved));

--- a/src/main/java/com/ozgen/telegrambinancebot/model/ExecutionStrategy.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/model/ExecutionStrategy.java
@@ -3,5 +3,8 @@ package com.ozgen.telegrambinancebot.model;
 public enum ExecutionStrategy {
     DEFAULT,     // Buy/Sell as a single order
     CHUNKED,      // Execute in multiple chunks
-    CHUNKED_PROGRESSIVE // todo add explanation
+    CHUNKED_PROGRESSIVE // Executes buy/sell orders in dynamic chunks based on market liquidity (e.g., quote volume).
+                        // Suitable for volatile or low-liquidity assets, allowing gradual position building.
+                        // The number of chunks is calculated dynamically, and each chunk is placed only if market
+                        // conditions (like short-term bullish trend and entry price range) are favorable.
 }

--- a/src/main/java/com/ozgen/telegrambinancebot/model/ExecutionStrategy.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/model/ExecutionStrategy.java
@@ -2,5 +2,6 @@ package com.ozgen.telegrambinancebot.model;
 
 public enum ExecutionStrategy {
     DEFAULT,     // Buy/Sell as a single order
-    CHUNKED      // Execute in multiple chunks
+    CHUNKED,      // Execute in multiple chunks
+    CHUNKED_PROGRESSIVE // todo add explanation
 }

--- a/src/main/java/com/ozgen/telegrambinancebot/model/bot/ChunkOrder.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/model/bot/ChunkOrder.java
@@ -31,7 +31,7 @@ public class ChunkOrder {
     private double leverage;              // calculated leverage per chunk
     private int takeProfitIndex;          // which TP this chunk targets (e.g. 0 = TP1)
     private int takeProfitAllocation;     // percent of coin to sell at this TP
-    private int totalChunkCount;   // total chunks expected for this signal
+    private int totalChunkCount;          // total chunks expected for this signal
 
     private int chunkIndex;
 

--- a/src/main/java/com/ozgen/telegrambinancebot/model/bot/ChunkOrder.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/model/bot/ChunkOrder.java
@@ -30,7 +30,7 @@ public class ChunkOrder {
     private double entryPoint;            // specific entry used in this chunk
     private double leverage;              // calculated leverage per chunk
     private int takeProfitIndex;          // which TP this chunk targets (e.g. 0 = TP1)
-    private int takeProfitAllocation;     // percent of coin to sell at this TP
+    private double takeProfitAllocation;  // percent of coin to sell at this TP
     private int totalChunkCount;          // total chunks expected for this signal
 
     private int chunkIndex;

--- a/src/main/java/com/ozgen/telegrambinancebot/model/bot/ChunkOrder.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/model/bot/ChunkOrder.java
@@ -27,12 +27,19 @@ public class ChunkOrder {
     private double buyPrice;
     private double sellPrice;
 
+    private double entryPoint;            // specific entry used in this chunk
+    private double leverage;              // calculated leverage per chunk
+    private int takeProfitIndex;          // which TP this chunk targets (e.g. 0 = TP1)
+    private int takeProfitAllocation;     // percent of coin to sell at this TP
+    private int totalChunkCount;   // total chunks expected for this signal
+
     private int chunkIndex;
 
     @Enumerated(EnumType.STRING)
     private OrderStatus status;
 
     @ManyToOne
+    @JoinColumn(name = "trading_signal_id")
     private TradingSignal tradingSignal;
 
     private Date createdAt;

--- a/src/main/java/com/ozgen/telegrambinancebot/model/events/IncomingProgressiveChunkedTradingSignalEvent.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/model/events/IncomingProgressiveChunkedTradingSignalEvent.java
@@ -1,0 +1,19 @@
+package com.ozgen.telegrambinancebot.model.events;
+
+import com.ozgen.telegrambinancebot.model.telegram.TradingSignal;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+@ToString
+public class IncomingProgressiveChunkedTradingSignalEvent extends ApplicationEvent {
+
+    private final TradingSignal tradingSignal;
+
+    public IncomingProgressiveChunkedTradingSignalEvent(Object source, TradingSignal tradingSignal) {
+        super(source);
+        this.tradingSignal = tradingSignal;
+    }
+
+}

--- a/src/main/java/com/ozgen/telegrambinancebot/model/events/NewChunkedBuyOrderEvent.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/model/events/NewChunkedBuyOrderEvent.java
@@ -9,11 +9,11 @@ import org.springframework.context.ApplicationEvent;
 
 @Getter
 @ToString
-public class NewChunkedBuyExecutionEvent extends ApplicationEvent {
+public class NewChunkedBuyOrderEvent extends ApplicationEvent {
     private final TradingSignal tradingSignal;
     private final TickerData tickerData;
 
-    public NewChunkedBuyExecutionEvent(Object source, TradingSignal tradingSignal, TickerData tickerData) {
+    public NewChunkedBuyOrderEvent(Object source, TradingSignal tradingSignal, TickerData tickerData) {
         super(source);
         this.tradingSignal = tradingSignal;
         this.tickerData = tickerData;

--- a/src/main/java/com/ozgen/telegrambinancebot/model/events/NewProgressiveChunkedBuyOrderEvent.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/model/events/NewProgressiveChunkedBuyOrderEvent.java
@@ -1,0 +1,21 @@
+package com.ozgen.telegrambinancebot.model.events;
+
+
+import com.ozgen.telegrambinancebot.model.binance.TickerData;
+import com.ozgen.telegrambinancebot.model.telegram.TradingSignal;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+@ToString
+public class NewProgressiveChunkedBuyOrderEvent extends ApplicationEvent {
+    private final TradingSignal tradingSignal;
+    private final TickerData tickerData;
+
+    public NewProgressiveChunkedBuyOrderEvent(Object source, TradingSignal tradingSignal, TickerData tickerData) {
+        super(source);
+        this.tradingSignal = tradingSignal;
+        this.tickerData = tickerData;
+    }
+}

--- a/src/main/java/com/ozgen/telegrambinancebot/model/events/NewProgressiveChunkedSellOrderEvent.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/model/events/NewProgressiveChunkedSellOrderEvent.java
@@ -1,0 +1,17 @@
+package com.ozgen.telegrambinancebot.model.events;
+
+import com.ozgen.telegrambinancebot.model.bot.ChunkOrder;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+@ToString
+public class NewProgressiveChunkedSellOrderEvent extends ApplicationEvent {
+    private final ChunkOrder chunkOrder;
+
+    public NewProgressiveChunkedSellOrderEvent(Object source, ChunkOrder chunkOrder) {
+        super(source);
+        this.chunkOrder = chunkOrder;
+    }
+}

--- a/src/main/java/com/ozgen/telegrambinancebot/scheduling/binance/BinanceProgressiveChunkOrderRetryToSellScheduler.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/scheduling/binance/BinanceProgressiveChunkOrderRetryToSellScheduler.java
@@ -1,0 +1,22 @@
+package com.ozgen.telegrambinancebot.scheduling.binance;
+
+import com.ozgen.telegrambinancebot.manager.binance.BinanceProgressiveChunkedSellOrderManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class BinanceProgressiveChunkOrderRetryToSellScheduler {
+
+    private final BinanceProgressiveChunkedSellOrderManager binanceProgressiveChunkedSellOrderManager;
+
+    @Scheduled(fixedRateString = "#{${app.bot.schedule.openSellOrder}}")
+    public void retryPendingChunks() {
+        log.info("BinanceProgressiveChunkOrderRetryToSellScheduler has been started");
+        this.binanceProgressiveChunkedSellOrderManager.retryPendingChunks();
+        log.info("BinanceProgressiveChunkOrderRetryToSellScheduler has been finished");
+    }
+}

--- a/src/main/java/com/ozgen/telegrambinancebot/scheduling/bot/BuyErrorProgressiveChunkOrdersScheduler.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/scheduling/bot/BuyErrorProgressiveChunkOrdersScheduler.java
@@ -1,0 +1,22 @@
+package com.ozgen.telegrambinancebot.scheduling.bot;
+
+import com.ozgen.telegrambinancebot.manager.binance.BinanceProgressiveChunkedBuyOrderManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class BuyErrorProgressiveChunkOrdersScheduler {
+
+    private final BinanceProgressiveChunkedBuyOrderManager binanceProgressiveChunkedBuyOrderManager;
+
+    @Scheduled(fixedRateString = "#{${app.bot.schedule.buyError}}")
+    public void processFailedProgressiveBuyChunks() {
+        log.info("BuyErrorProgressiveChunkOrdersScheduler has been started");
+        this.binanceProgressiveChunkedBuyOrderManager.processFailedProgressiveBuyChunks();
+        log.info("BuyErrorProgressiveChunkOrdersScheduler has been finished");
+    }
+}

--- a/src/main/java/com/ozgen/telegrambinancebot/scheduling/bot/ProgressiveChunkBuyOrdersScheduler.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/scheduling/bot/ProgressiveChunkBuyOrdersScheduler.java
@@ -1,0 +1,22 @@
+package com.ozgen.telegrambinancebot.scheduling.bot;
+
+import com.ozgen.telegrambinancebot.manager.binance.BinanceProgressiveChunkedBuyOrderManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ProgressiveChunkBuyOrdersScheduler {
+
+    private final BinanceProgressiveChunkedBuyOrderManager binanceProgressiveChunkedBuyOrderManager;
+
+    @Scheduled(fixedRateString = "#{${app.bot.schedule.sellLater}}")
+    public void processSellLaterOrders() {
+        log.info("ProgressiveChunkBuyOrdersScheduler has been started");
+        this.binanceProgressiveChunkedBuyOrderManager.processExecutedProgressiveBuyChunks();
+        log.info("ProgressiveChunkBuyOrdersScheduler has been finished");
+    }
+}

--- a/src/main/java/com/ozgen/telegrambinancebot/scheduling/bot/SellErrorProgressiveChunkOrdersScheduler.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/scheduling/bot/SellErrorProgressiveChunkOrdersScheduler.java
@@ -1,0 +1,22 @@
+package com.ozgen.telegrambinancebot.scheduling.bot;
+
+import com.ozgen.telegrambinancebot.manager.binance.BinanceProgressiveChunkedSellOrderManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SellErrorProgressiveChunkOrdersScheduler {
+
+    private final BinanceProgressiveChunkedSellOrderManager binanceProgressiveChunkedSellOrderManager;
+
+    @Scheduled(fixedRateString = "#{${app.bot.schedule.sellError}}")
+    public void processSellChunkOrders() {
+        log.info("SellErrorProgressiveChunkOrdersScheduler has been started");
+        this.binanceProgressiveChunkedSellOrderManager.processSellChunkOrders();
+        log.info("SellErrorProgressiveChunkOrdersScheduler has been finished");
+    }
+}

--- a/src/main/java/com/ozgen/telegrambinancebot/scheduling/bot/TradingSignalScheduler.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/scheduling/bot/TradingSignalScheduler.java
@@ -28,4 +28,11 @@ public class TradingSignalScheduler {
         this.tradeSignalManager.processInitTradingSignalsForChunkOrders();
         log.info("TradingSignalScheduler for chunk orders has been finished");
     }
+
+    @Scheduled(fixedRateString = "#{${app.bot.schedule.tradingSignal}}")
+    public void processInitTradingSignalsForProgressiveChunkOrders() {
+        log.info("TradingSignalScheduler for progressive chunk orders has been started");
+        this.tradeSignalManager.processInitTradingSignalsForProgressiveChunkOrders();
+        log.info("TradingSignalScheduler for progressive chunk orders has been finished");
+    }
 }

--- a/src/main/java/com/ozgen/telegrambinancebot/service/BotOrderService.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/service/BotOrderService.java
@@ -4,6 +4,7 @@ import com.ozgen.telegrambinancebot.adapters.repository.BuyOrderRepository;
 import com.ozgen.telegrambinancebot.adapters.repository.ChunkOrderRepository;
 import com.ozgen.telegrambinancebot.adapters.repository.SellOrderRepository;
 import com.ozgen.telegrambinancebot.adapters.repository.TradingSignalRepository;
+import com.ozgen.telegrambinancebot.model.ExecutionStrategy;
 import com.ozgen.telegrambinancebot.model.ProcessStatus;
 import com.ozgen.telegrambinancebot.model.bot.BuyOrder;
 import com.ozgen.telegrambinancebot.model.bot.ChunkOrder;
@@ -129,11 +130,33 @@ public class BotOrderService {
 
     public List<ChunkOrder> getBuyChunksByStatusesAndDate(List<OrderStatus> statuses, Date date) {
         try {
-            List<ChunkOrder> chunks = chunkOrderRepository.findAllByCreatedAtAfterAndStatusIn(date, statuses);
+            List<ChunkOrder> chunks = chunkOrderRepository.findAllByCreatedAtAfterAndStatusInAndTradingSignal_ExecutionStrategy(date, statuses, ExecutionStrategy.CHUNKED);
             log.info("Retrieved {} chunk orders with date {}", chunks.size(), date);
             return chunks;
         } catch (Exception e) {
             log.error("Error retrieving chunk orders by  date {}: {}", date, e.getMessage(), e);
+            return List.of();
+        }
+    }
+
+    public List<ChunkOrder> getBuyProgressiveChunksByStatusesAndDate(List<OrderStatus> statuses, Date date) {
+        try {
+            List<ChunkOrder> chunks = chunkOrderRepository.findAllByCreatedAtAfterAndStatusInAndTradingSignal_ExecutionStrategy(date, statuses, ExecutionStrategy.CHUNKED_PROGRESSIVE);
+            log.info("Retrieved {} progressive chunk orders with date {}", chunks.size(), date);
+            return chunks;
+        } catch (Exception e) {
+            log.error("Error retrieving chunk orders by  date {}: {}", date, e.getMessage(), e);
+            return List.of();
+        }
+    }
+
+    public List<ChunkOrder> getChunksBySignalAndStatuses(String tradingSignalId, List<OrderStatus> statuses) {
+        try {
+            List<ChunkOrder> chunks = chunkOrderRepository.findAllByTradingSignalIdAndAndStatusIn(tradingSignalId, statuses);
+            log.info("Retrieved {} chunk orders with tradingSignal {}", chunks.size(), tradingSignalId);
+            return chunks;
+        } catch (Exception e) {
+            log.error("Error retrieving chunk orders by  tradingSignal {}: {}", tradingSignalId, e.getMessage(), e);
             return List.of();
         }
     }

--- a/src/main/java/com/ozgen/telegrambinancebot/service/BotOrderService.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/service/BotOrderService.java
@@ -139,7 +139,7 @@ public class BotOrderService {
         }
     }
 
-    public List<ChunkOrder> getBuyProgressiveChunksByStatusesAndDate(List<OrderStatus> statuses, Date date) {
+    public List<ChunkOrder> getProgressiveChunksByStatusesAndDate(List<OrderStatus> statuses, Date date) {
         try {
             List<ChunkOrder> chunks = chunkOrderRepository.findAllByCreatedAtAfterAndStatusInAndTradingSignal_ExecutionStrategy(date, statuses, ExecutionStrategy.CHUNKED_PROGRESSIVE);
             log.info("Retrieved {} progressive chunk orders with date {}", chunks.size(), date);
@@ -152,7 +152,7 @@ public class BotOrderService {
 
     public List<ChunkOrder> getChunksBySignalAndStatuses(String tradingSignalId, List<OrderStatus> statuses) {
         try {
-            List<ChunkOrder> chunks = chunkOrderRepository.findAllByTradingSignalIdAndAndStatusIn(tradingSignalId, statuses);
+            List<ChunkOrder> chunks = chunkOrderRepository.findAllByTradingSignalIdAndStatusIn(tradingSignalId, statuses);
             log.info("Retrieved {} chunk orders with tradingSignal {}", chunks.size(), tradingSignalId);
             return chunks;
         } catch (Exception e) {

--- a/src/main/java/com/ozgen/telegrambinancebot/service/TradingSignalService.java
+++ b/src/main/java/com/ozgen/telegrambinancebot/service/TradingSignalService.java
@@ -61,4 +61,8 @@ public class TradingSignalService {
     public List<TradingSignal> getAllTradingSignalsAfterDateAndIsProcessInForChunkOrders(Date date, List<Integer> processStatuses) {
         return this.repository.findAllByCreatedAtAfterAndIsProcessedInAndStrategyInAndExecutionStrategy(date, processStatuses, List.of(TradingStrategy.DEFAULT, TradingStrategy.SELL_LATER), ExecutionStrategy.CHUNKED);
     }
+
+    public List<TradingSignal> getAllTradingSignalsAfterDateAndIsProcessInForPrChunkOrders(Date date, List<Integer> processStatuses) {
+        return this.repository.findAllByCreatedAtAfterAndIsProcessedInAndStrategyInAndExecutionStrategy(date, processStatuses, List.of(TradingStrategy.DEFAULT, TradingStrategy.SELL_LATER), ExecutionStrategy.CHUNKED_PROGRESSIVE);
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,8 +17,8 @@ bot.telegram.error.enabled=false
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 # Hibernate ddl auto (create, create-drop, validate, update)
 spring.jpa.hibernate.ddl-auto=update
-# app execution strategy: CHUNKED or DEFAULT
-app.bot.execution.strategy=CHUNKED
+# app execution strategy: CHUNKED, CHUNKED_PROGRESSIVE or DEFAULT
+app.bot.execution.strategy=CHUNKED_PROGRESSIVE
 app.bot.execution.minQuoteVolume=10000
 # app investment
 app.bot.investment.currency=BTC

--- a/src/test/java/com/ozgen/telegrambinancebot/TelegramBinanceBotApplicationTests.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/TelegramBinanceBotApplicationTests.java
@@ -5,12 +5,16 @@ import com.ozgen.telegrambinancebot.configuration.BinanceTestConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
 @Import(BinanceTestConfig.class)
+@ComponentScan(basePackages = "com.ozgen.telegrambinancebot.adapters")
+@EnableJpaRepositories(basePackages = "com.ozgen.telegrambinancebot.adapters.repository")
 class TelegramBinanceBotApplicationTests {
 
     @MockBean

--- a/src/test/java/com/ozgen/telegrambinancebot/TelegramBinanceBotApplicationTests.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/TelegramBinanceBotApplicationTests.java
@@ -5,16 +5,12 @@ import com.ozgen.telegrambinancebot.configuration.BinanceTestConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
 @Import(BinanceTestConfig.class)
-@ComponentScan(basePackages = "com.ozgen.telegrambinancebot.adapters")
-@EnableJpaRepositories(basePackages = "com.ozgen.telegrambinancebot.adapters.repository")
 class TelegramBinanceBotApplicationTests {
 
     @MockBean

--- a/src/test/java/com/ozgen/telegrambinancebot/adapters/events/IncomingChunkedTradingSignalEventListenerTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/adapters/events/IncomingChunkedTradingSignalEventListenerTest.java
@@ -1,0 +1,31 @@
+package com.ozgen.telegrambinancebot.adapters.events;
+
+import com.ozgen.telegrambinancebot.manager.binance.BinanceTradingSignalManager;
+import com.ozgen.telegrambinancebot.model.events.IncomingChunkedTradingSignalEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class IncomingChunkedTradingSignalEventListenerTest {
+
+    private BinanceTradingSignalManager binanceTradingSignalManager;
+    private IncomingChunkedTradingSignalEventListener listener;
+
+    @BeforeEach
+    void setUp() {
+        binanceTradingSignalManager = Mockito.mock(BinanceTradingSignalManager.class);
+        listener = new IncomingChunkedTradingSignalEventListener(binanceTradingSignalManager);
+    }
+
+    @Test
+    void shouldDelegateEventToManager() {
+        // given
+        IncomingChunkedTradingSignalEvent event = Mockito.mock(IncomingChunkedTradingSignalEvent.class);
+
+        // when
+        listener.onApplicationEvent(event);
+
+        // then
+        Mockito.verify(binanceTradingSignalManager).processIncomingChunkedTradingSignalEvent(event);
+    }
+}

--- a/src/test/java/com/ozgen/telegrambinancebot/adapters/events/IncomingProgressiveChunkedTradingSignalEventListenerTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/adapters/events/IncomingProgressiveChunkedTradingSignalEventListenerTest.java
@@ -1,0 +1,32 @@
+package com.ozgen.telegrambinancebot.adapters.events;
+
+import com.ozgen.telegrambinancebot.manager.binance.BinanceTradingSignalManager;
+import com.ozgen.telegrambinancebot.model.events.IncomingProgressiveChunkedTradingSignalEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class IncomingProgressiveChunkedTradingSignalEventListenerTest {
+
+    private BinanceTradingSignalManager binanceTradingSignalManager;
+    private IncomingProgressiveChunkedTradingSignalEventListener listener;
+
+    @BeforeEach
+    void setUp() {
+        binanceTradingSignalManager = Mockito.mock(BinanceTradingSignalManager.class);
+        listener = new IncomingProgressiveChunkedTradingSignalEventListener(binanceTradingSignalManager);
+    }
+
+    @Test
+    void shouldDelegateProgressiveEventToManager() {
+        // given
+        IncomingProgressiveChunkedTradingSignalEvent event = Mockito.mock(IncomingProgressiveChunkedTradingSignalEvent.class);
+
+        // when
+        listener.onApplicationEvent(event);
+
+        // then
+        Mockito.verify(binanceTradingSignalManager)
+                .processIncomingProgressiveChunkedTradingSignalEvent(event);
+    }
+}

--- a/src/test/java/com/ozgen/telegrambinancebot/adapters/events/NewBuyOrderEventListenerTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/adapters/events/NewBuyOrderEventListenerTest.java
@@ -14,6 +14,7 @@ import org.mockito.MockitoAnnotations;
 import static org.mockito.Mockito.verify;
 
 public class NewBuyOrderEventListenerTest {
+
     @Mock
     private BinanceBuyOrderManager binanceBuyOrderManager;
 

--- a/src/test/java/com/ozgen/telegrambinancebot/adapters/events/NewProgressiveChunkSellOrderEventListenerTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/adapters/events/NewProgressiveChunkSellOrderEventListenerTest.java
@@ -1,0 +1,31 @@
+package com.ozgen.telegrambinancebot.adapters.events;
+
+import com.ozgen.telegrambinancebot.manager.binance.BinanceProgressiveChunkedSellOrderManager;
+import com.ozgen.telegrambinancebot.model.events.NewProgressiveChunkedSellOrderEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class NewProgressiveChunkSellOrderEventListenerTest {
+
+    private BinanceProgressiveChunkedSellOrderManager manager;
+    private NewProgressiveChunkSellOrderEventListener listener;
+
+    @BeforeEach
+    void setUp() {
+        manager = Mockito.mock(BinanceProgressiveChunkedSellOrderManager.class);
+        listener = new NewProgressiveChunkSellOrderEventListener(manager);
+    }
+
+    @Test
+    void shouldDelegateEventToManager() {
+        // given
+        NewProgressiveChunkedSellOrderEvent event = Mockito.mock(NewProgressiveChunkedSellOrderEvent.class);
+
+        // when
+        listener.onApplicationEvent(event);
+
+        // then
+        Mockito.verify(manager).onNewSellProgressiveChunkOrderEvent(event);
+    }
+}

--- a/src/test/java/com/ozgen/telegrambinancebot/adapters/events/NewProgressiveChunkedBuyOrderEventListenerTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/adapters/events/NewProgressiveChunkedBuyOrderEventListenerTest.java
@@ -1,0 +1,31 @@
+package com.ozgen.telegrambinancebot.adapters.events;
+
+import com.ozgen.telegrambinancebot.manager.binance.BinanceProgressiveChunkedBuyOrderManager;
+import com.ozgen.telegrambinancebot.model.events.NewProgressiveChunkedBuyOrderEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class NewProgressiveChunkedBuyOrderEventListenerTest {
+
+    private BinanceProgressiveChunkedBuyOrderManager manager;
+    private NewProgressiveChunkedBuyOrderEventListener listener;
+
+    @BeforeEach
+    void setUp() {
+        manager = Mockito.mock(BinanceProgressiveChunkedBuyOrderManager.class);
+        listener = new NewProgressiveChunkedBuyOrderEventListener(manager);
+    }
+
+    @Test
+    void shouldDelegateEventToManager() {
+        // given
+        NewProgressiveChunkedBuyOrderEvent event = Mockito.mock(NewProgressiveChunkedBuyOrderEvent.class);
+
+        // when
+        listener.onApplicationEvent(event);
+
+        // then
+        Mockito.verify(manager).handleProgressiveChunkedBuy(event);
+    }
+}

--- a/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/AssetBalanceRepositoryTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/AssetBalanceRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.ozgen.telegrambinancebot.adapters.repository;
 
-import com.ozgen.telegrambinancebot.adapters.repository.AssetBalanceRepository;
 import com.ozgen.telegrambinancebot.model.binance.AssetBalance;
 import com.ozgen.telegrambinancebot.utils.TestData;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,7 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
@@ -17,7 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 
 @DataJpaTest
-@TestPropertySource(locations = "classpath:application-test.properties")
+@ActiveProfiles("test")
+@EnableJpaRepositories(basePackages = "com.ozgen.telegrambinancebot.adapters.repository")
 public class AssetBalanceRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/BuyOrderRepositoryTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/BuyOrderRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.ozgen.telegrambinancebot.adapters.repository;
 
-import com.ozgen.telegrambinancebot.adapters.repository.BuyOrderRepository;
 import com.ozgen.telegrambinancebot.model.ProcessStatus;
 import com.ozgen.telegrambinancebot.model.bot.BuyOrder;
 import com.ozgen.telegrambinancebot.model.telegram.TradingSignal;
@@ -10,17 +9,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
-@TestPropertySource(locations = "classpath:application-test.properties")
+@ActiveProfiles("test")
+@EnableJpaRepositories(basePackages = "com.ozgen.telegrambinancebot.adapters.repository")
 public class BuyOrderRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/CancelAndNewOrderResponseRepositoryTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/CancelAndNewOrderResponseRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.ozgen.telegrambinancebot.adapters.repository;
 
 
-import com.ozgen.telegrambinancebot.adapters.repository.CancelAndNewOrderResponseRepository;
 import com.ozgen.telegrambinancebot.model.binance.CancelAndNewOrderResponse;
 import com.ozgen.telegrambinancebot.utils.TestData;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,7 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
@@ -17,7 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @DataJpaTest
-@TestPropertySource(locations = "classpath:application-test.properties")
+@ActiveProfiles("test")
+@EnableJpaRepositories(basePackages = "com.ozgen.telegrambinancebot.adapters.repository")
 public class CancelAndNewOrderResponseRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/ChunkOrderRepositoryTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/ChunkOrderRepositoryTest.java
@@ -1,7 +1,10 @@
 package com.ozgen.telegrambinancebot.adapters.repository;
 
+import com.ozgen.telegrambinancebot.model.ExecutionStrategy;
 import com.ozgen.telegrambinancebot.model.bot.ChunkOrder;
 import com.ozgen.telegrambinancebot.model.bot.OrderStatus;
+import com.ozgen.telegrambinancebot.model.telegram.TradingSignal;
+import com.ozgen.telegrambinancebot.utils.TestData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +35,10 @@ public class ChunkOrderRepositoryTest {
         this.chunkOrder = new ChunkOrder();
         this.chunkOrder.setStatus(OrderStatus.BUY_EXECUTED);
         this.chunkOrder.setCreatedAt(new Date(System.currentTimeMillis() - 1000)); // 1 second ago
+        TradingSignal tradingSignal = TestData.getTradingSignal();
+        tradingSignal.setExecutionStrategy(ExecutionStrategy.CHUNKED);
+        this.entityManager.persist(tradingSignal);
+        this.chunkOrder.setTradingSignal(tradingSignal);
 
         this.chunkOrder = this.entityManager.persist(this.chunkOrder);
     }
@@ -47,9 +54,10 @@ public class ChunkOrderRepositoryTest {
     @Test
     public void testFindAllByCreatedAtAfterAndStatusIn() {
         Date beforeCreation = new Date(System.currentTimeMillis() - 2000); // 2 seconds ago
-        List<ChunkOrder> result = this.chunkOrderRepository.findAllByCreatedAtAfterAndStatusIn(
+        List<ChunkOrder> result = this.chunkOrderRepository.findAllByCreatedAtAfterAndStatusInAndTradingSignal_ExecutionStrategy(
                 beforeCreation,
-                List.of(OrderStatus.BUY_EXECUTED)
+                List.of(OrderStatus.BUY_EXECUTED),
+                ExecutionStrategy.CHUNKED
         );
         assertFalse(result.isEmpty());
         assertEquals(1, result.size());

--- a/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/ChunkOrderRepositoryTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/ChunkOrderRepositoryTest.java
@@ -10,7 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Date;
 import java.util.List;
@@ -19,7 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @DataJpaTest
-@TestPropertySource(locations = "classpath:application-test.properties")
+@ActiveProfiles("test")
+@EnableJpaRepositories(basePackages = "com.ozgen.telegrambinancebot.adapters.repository")
 public class ChunkOrderRepositoryTest {
 
     @Autowired
@@ -61,5 +63,22 @@ public class ChunkOrderRepositoryTest {
         );
         assertFalse(result.isEmpty());
         assertEquals(1, result.size());
+    }
+
+    @Test
+    public void testFindAllByTradingSignalIdAndStatusIn() {
+        // given
+        List<OrderStatus> statuses = List.of(OrderStatus.BUY_EXECUTED);
+        String tradingSignalId = chunkOrder.getTradingSignal().getId();
+
+        // when
+        List<ChunkOrder> result = chunkOrderRepository
+                .findAllByTradingSignalIdAndStatusIn(tradingSignalId, statuses);
+
+        // then
+        assertFalse(result.isEmpty(), "Result should not be empty");
+        assertEquals(1, result.size(), "Should find one matching ChunkOrder");
+        assertEquals(OrderStatus.BUY_EXECUTED, result.getFirst().getStatus());
+        assertEquals(tradingSignalId, result.getFirst().getTradingSignal().getId());
     }
 }

--- a/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/FutureTradeRepositoryTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/FutureTradeRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.ozgen.telegrambinancebot.adapters.repository;
 
 
-import com.ozgen.telegrambinancebot.adapters.repository.FutureTradeRepository;
 import com.ozgen.telegrambinancebot.model.TradeStatus;
 import com.ozgen.telegrambinancebot.model.bot.FutureTrade;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,7 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 import java.util.UUID;
@@ -17,7 +17,8 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
-@TestPropertySource(locations = "classpath:application-test.properties")
+@ActiveProfiles("test")
+@EnableJpaRepositories(basePackages = "com.ozgen.telegrambinancebot.adapters.repository")
 public class FutureTradeRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/OpenOrderRepositoryTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/OpenOrderRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.ozgen.telegrambinancebot.adapters.repository;
 
 
-import com.ozgen.telegrambinancebot.adapters.repository.OpenOrderRepository;
 import com.ozgen.telegrambinancebot.model.binance.OpenOrder;
 import com.ozgen.telegrambinancebot.utils.TestData;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,7 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
@@ -17,7 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @DataJpaTest
-@TestPropertySource(locations = "classpath:application-test.properties")
+@ActiveProfiles("test")
+@EnableJpaRepositories(basePackages = "com.ozgen.telegrambinancebot.adapters.repository")
 public class OpenOrderRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/OrderInfoRepositoryTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/OrderInfoRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.ozgen.telegrambinancebot.adapters.repository;
 
-import com.ozgen.telegrambinancebot.adapters.repository.OrderInfoRepository;
 import com.ozgen.telegrambinancebot.model.binance.OrderInfo;
 import com.ozgen.telegrambinancebot.utils.TestData;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,7 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
@@ -17,7 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 
 @DataJpaTest
-@TestPropertySource(locations = "classpath:application-test.properties")
+@ActiveProfiles("test")
+@EnableJpaRepositories(basePackages = "com.ozgen.telegrambinancebot.adapters.repository")
 public class OrderInfoRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/OrderResponseRepositoryTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/OrderResponseRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.ozgen.telegrambinancebot.adapters.repository;
 
-import com.ozgen.telegrambinancebot.adapters.repository.OrderResponseRepository;
 import com.ozgen.telegrambinancebot.model.binance.OrderResponse;
 import com.ozgen.telegrambinancebot.utils.TestData;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,7 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
@@ -17,7 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 
 @DataJpaTest
-@TestPropertySource(locations = "classpath:application-test.properties")
+@ActiveProfiles("test")
+@EnableJpaRepositories(basePackages = "com.ozgen.telegrambinancebot.adapters.repository")
 public class OrderResponseRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/SellOrderRepositoryTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/SellOrderRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.ozgen.telegrambinancebot.adapters.repository;
 
-import com.ozgen.telegrambinancebot.adapters.repository.SellOrderRepository;
 import com.ozgen.telegrambinancebot.model.bot.SellOrder;
 import com.ozgen.telegrambinancebot.model.telegram.TradingSignal;
 import com.ozgen.telegrambinancebot.utils.TestData;
@@ -9,17 +8,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
-@TestPropertySource(locations = "classpath:application-test.properties")
+@ActiveProfiles("test")
+@EnableJpaRepositories(basePackages = "com.ozgen.telegrambinancebot.adapters.repository")
 public class SellOrderRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/TickerDataRepositoryTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/TickerDataRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.ozgen.telegrambinancebot.adapters.repository;
 
-import com.ozgen.telegrambinancebot.adapters.repository.TickerDataRepository;
 import com.ozgen.telegrambinancebot.model.binance.TickerData;
 import com.ozgen.telegrambinancebot.utils.TestData;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,7 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
@@ -17,7 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 
 @DataJpaTest
-@TestPropertySource(locations = "classpath:application-test.properties")
+@ActiveProfiles("test")
+@EnableJpaRepositories(basePackages = "com.ozgen.telegrambinancebot.adapters.repository")
 public class TickerDataRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/TradingSignalRepositoryTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/adapters/repository/TradingSignalRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.ozgen.telegrambinancebot.adapters.repository;
 
-import com.ozgen.telegrambinancebot.adapters.repository.TradingSignalRepository;
 import com.ozgen.telegrambinancebot.model.ExecutionStrategy;
 import com.ozgen.telegrambinancebot.model.TradingStrategy;
 import com.ozgen.telegrambinancebot.model.telegram.TradingSignal;
@@ -9,7 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -18,7 +18,8 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
-@TestPropertySource(locations = "classpath:application-test.properties")
+@ActiveProfiles("test")
+@EnableJpaRepositories(basePackages = "com.ozgen.telegrambinancebot.adapters.repository")
 public class TradingSignalRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/ozgen/telegrambinancebot/manager/binance/BinanceChunkBuyOrderManagerTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/manager/binance/BinanceChunkBuyOrderManagerTest.java
@@ -9,7 +9,7 @@ import com.ozgen.telegrambinancebot.model.binance.TickerData;
 import com.ozgen.telegrambinancebot.model.bot.ChunkOrder;
 import com.ozgen.telegrambinancebot.model.events.ErrorEvent;
 import com.ozgen.telegrambinancebot.model.events.InfoEvent;
-import com.ozgen.telegrambinancebot.model.events.NewChunkedBuyExecutionEvent;
+import com.ozgen.telegrambinancebot.model.events.NewChunkedBuyOrderEvent;
 import com.ozgen.telegrambinancebot.model.events.NewSellChunkOrderEvent;
 import com.ozgen.telegrambinancebot.model.telegram.TradingSignal;
 import com.ozgen.telegrambinancebot.service.BotOrderService;
@@ -65,10 +65,11 @@ class BinanceChunkBuyOrderManagerTest {
         signal.setSymbol("BTCUSDT");
         signal.setEntryEnd("90");
 
-        NewChunkedBuyExecutionEvent event = new NewChunkedBuyExecutionEvent(this, signal, ticker);
+        NewChunkedBuyOrderEvent event = new NewChunkedBuyOrderEvent(this, signal, ticker);
 
         when(binanceHelper.getUserAssets()).thenReturn(List.of(mock(AssetBalance.class)));
         when(binanceHelper.hasAccountEnoughAsset(any(), eq(signal))).thenReturn(true);
+        when(binanceHelper.calculateDynamicChunkCount(anyDouble())).thenReturn(1);
         when(botConfiguration.getAmount()).thenReturn(100.0);
         when(botConfiguration.getPercentageInc()).thenReturn(1.0);
         when(binanceApiManager.getListOfKlineData(any(), any())).thenReturn(List.of(
@@ -93,7 +94,7 @@ class BinanceChunkBuyOrderManagerTest {
         TradingSignal signal = new TradingSignal();
         signal.setSymbol("BTCUSDT");
 
-        NewChunkedBuyExecutionEvent event = new NewChunkedBuyExecutionEvent(this, signal, ticker);
+        NewChunkedBuyOrderEvent event = new NewChunkedBuyOrderEvent(this, signal, ticker);
 
         when(binanceHelper.getUserAssets()).thenReturn(Collections.emptyList());
         when(binanceHelper.hasAccountEnoughAsset(any(), any())).thenReturn(false);
@@ -139,7 +140,7 @@ class BinanceChunkBuyOrderManagerTest {
         when(binanceApiManager.getListOfKlineData(any(), any())).thenReturn(List.of(mockKline(10.0)));
         when(appConfiguration.getMinQuoteVolume()).thenReturn(500.0);
 
-        manager.handleChunkedBuyEvent(new NewChunkedBuyExecutionEvent(this, signal, ticker));
+        manager.handleChunkedBuyEvent(new NewChunkedBuyOrderEvent(this, signal, ticker));
 
         verify(botOrderService, never()).saveChunkOrder(any());
     }

--- a/src/test/java/com/ozgen/telegrambinancebot/manager/binance/BinanceHelperTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/manager/binance/BinanceHelperTest.java
@@ -4,7 +4,9 @@ package com.ozgen.telegrambinancebot.manager.binance;
 import com.ozgen.telegrambinancebot.configuration.properties.BotConfiguration;
 import com.ozgen.telegrambinancebot.configuration.properties.ScheduleConfiguration;
 import com.ozgen.telegrambinancebot.model.binance.AssetBalance;
+import com.ozgen.telegrambinancebot.model.binance.KlineData;
 import com.ozgen.telegrambinancebot.model.binance.TickerData;
+import com.ozgen.telegrambinancebot.model.bot.ChunkOrder;
 import com.ozgen.telegrambinancebot.model.telegram.TradingSignal;
 import com.ozgen.telegrambinancebot.utils.DateFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -216,5 +218,150 @@ class BinanceHelperTest {
             // Assert
             assertEquals(expectedDate, result);
         }
+    }
+
+    @Test
+    void testIsShortTermBullish_shouldReturnTrue_whenCurrentCloseGreaterThanPrevious() {
+        List<KlineData> klines = List.of(
+                new KlineData(0L, "0.9", "1.0", "0.8", "1.0", "100", 0L, 1000.0, 100, "50", "500"),
+                new KlineData(1L, "1.0", "1.2", "0.9", "1.1", "150", 1L, 1200.0, 120, "60", "600")
+        );
+        assertTrue(binanceHelper.isShortTermBullish(klines));
+    }
+
+    @Test
+    void testIsShortTermBullish_shouldReturnFalse_whenCurrentCloseLessThanPrevious() {
+        List<KlineData> klines = List.of(
+                new KlineData(0L, "1.0", "1.1", "0.9", "1.2", "100", 0L, 1000.0, 100, "50", "500"),
+                new KlineData(1L, "1.2", "1.3", "1.0", "1.1", "150", 1L, 1200.0, 120, "60", "600")
+        );
+        assertFalse(binanceHelper.isShortTermBullish(klines));
+    }
+
+    @Test
+    void testIsShortTermBullish_shouldReturnFalse_whenOnlyOneKline() {
+        List<KlineData> klines = List.of(
+                new KlineData(0L, "1.0", "1.1", "0.9", "1.0", "100", 0L, 1000.0, 100, "50", "500")
+        );
+        assertFalse(binanceHelper.isShortTermBullish(klines));
+    }
+
+    @Test
+    void testIsShortTermBullish_shouldReturnFalse_whenNullList() {
+        assertFalse(binanceHelper.isShortTermBullish(null));
+    }
+
+    @Test
+    void testCalculateSellAmount_shouldReturnMinBalance() {
+        AssetBalance balance = new AssetBalance();
+        balance.setAsset("ABC");
+        balance.setFree("0.5");
+
+        ChunkOrder chunkOrder = new ChunkOrder();
+        chunkOrder.setSymbol("BTCABC");
+        chunkOrder.setTakeProfitAllocation(50);  // 50%
+        chunkOrder.setBuyCoinAmount(2.0);          // desired = 1.0
+
+        double result = binanceHelper.calculateSellAmount(List.of(balance), chunkOrder);
+        assertEquals(0.5, result); // balance is lower than desired
+    }
+
+    @Test
+    void testCalculateSellAmount_shouldReturnMinDesired() {
+        AssetBalance balance = new AssetBalance();
+        balance.setAsset("ABC");
+        balance.setFree("0.8");
+
+        ChunkOrder chunkOrder = new ChunkOrder();
+        chunkOrder.setSymbol("BTCABC");
+        chunkOrder.setTakeProfitAllocation(50);  // 50%
+        chunkOrder.setBuyCoinAmount(1.0);          // desired = 0.5
+
+        double result = binanceHelper.calculateSellAmount(List.of(balance), chunkOrder);
+        assertEquals(0.5, result); // desired is lower than balance
+    }
+
+    @Test
+    void testCalculateSellAmount_shouldThrow_whenCoinSymbolNotResolved() {
+        ChunkOrder chunkOrder = new ChunkOrder();
+        chunkOrder.setSymbol("UNKNOWNUSDT");
+        chunkOrder.setTakeProfitAllocation(50);
+        chunkOrder.setBuyCoinAmount(1.0);
+
+        assertThrows(IllegalArgumentException.class, () ->
+                binanceHelper.calculateSellAmount(List.of(), chunkOrder)
+        );
+    }
+
+    @Test
+    void testCalculateDynamicChunkCount_shouldReturn5() {
+        int result = binanceHelper.calculateDynamicChunkCount(150_000);
+        assertEquals(5, result);
+    }
+
+    @Test
+    void testCalculateDynamicChunkCount_shouldReturn4() {
+        int result = binanceHelper.calculateDynamicChunkCount(75_000);
+        assertEquals(4, result);
+    }
+
+    @Test
+    void testCalculateDynamicChunkCount_shouldReturn3() {
+        int result = binanceHelper.calculateDynamicChunkCount(30_000);
+        assertEquals(3, result);
+    }
+
+    @Test
+    void testCalculateDynamicChunkCount_shouldReturn2() {
+        int result = binanceHelper.calculateDynamicChunkCount(10_000);
+        assertEquals(2, result);
+    }
+
+    @Test
+    void testIsCoinPriceAvailableToSell_shouldReturnTrue_whenLastPriceHigherThanTarget() {
+        double buyPrice = 100.0;
+        double profitPercentage = 5.0; // expect target = 105.0
+        String lastPriceStr = "106.0";
+
+        when(botConfiguration.getProfitPercentage()).thenReturn(profitPercentage);
+
+        TickerData tickerData = new TickerData();
+        tickerData.setLastPrice(lastPriceStr);
+
+        boolean result = binanceHelper.isCoinPriceAvailableToSell(buyPrice, tickerData);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void testIsCoinPriceAvailableToSell_shouldReturnTrue_whenLastPriceEqualsTarget() {
+        double buyPrice = 100.0;
+        double profitPercentage = 5.0; // expect target = 105.0
+        String lastPriceStr = "105.0";
+
+        when(botConfiguration.getProfitPercentage()).thenReturn(profitPercentage);
+
+        TickerData tickerData = new TickerData();
+        tickerData.setLastPrice(lastPriceStr);
+
+        boolean result = binanceHelper.isCoinPriceAvailableToSell(buyPrice, tickerData);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void testIsCoinPriceAvailableToSell_shouldReturnFalse_whenLastPriceBelowTarget() {
+        double buyPrice = 100.0;
+        double profitPercentage = 5.0; // expect target = 105.0
+        String lastPriceStr = "104.0";
+
+        when(botConfiguration.getProfitPercentage()).thenReturn(profitPercentage);
+
+        TickerData tickerData = new TickerData();
+        tickerData.setLastPrice(lastPriceStr);
+
+        boolean result = binanceHelper.isCoinPriceAvailableToSell(buyPrice, tickerData);
+
+        assertFalse(result);
     }
 }

--- a/src/test/java/com/ozgen/telegrambinancebot/manager/binance/BinanceProgressiveChunkedBuyOrderManagerTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/manager/binance/BinanceProgressiveChunkedBuyOrderManagerTest.java
@@ -1,0 +1,485 @@
+package com.ozgen.telegrambinancebot.manager.binance;
+
+import com.ozgen.telegrambinancebot.configuration.properties.AppConfiguration;
+import com.ozgen.telegrambinancebot.configuration.properties.BotConfiguration;
+import com.ozgen.telegrambinancebot.model.binance.IntervalType;
+import com.ozgen.telegrambinancebot.model.binance.KlineData;
+import com.ozgen.telegrambinancebot.model.binance.TickerData;
+import com.ozgen.telegrambinancebot.model.bot.ChunkOrder;
+import com.ozgen.telegrambinancebot.model.bot.OrderStatus;
+import com.ozgen.telegrambinancebot.model.events.ErrorEvent;
+import com.ozgen.telegrambinancebot.model.events.InfoEvent;
+import com.ozgen.telegrambinancebot.model.events.NewProgressiveChunkedBuyOrderEvent;
+import com.ozgen.telegrambinancebot.model.events.NewProgressiveChunkedSellOrderEvent;
+import com.ozgen.telegrambinancebot.model.telegram.TradingSignal;
+import com.ozgen.telegrambinancebot.service.BotOrderService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class BinanceProgressiveChunkedBuyOrderManagerTest {
+
+    @Mock
+    private BinanceApiManager binanceApiManager;
+    @Mock
+    private BotOrderService botOrderService;
+    @Mock
+    private BinanceHelper binanceHelper;
+    @Mock
+    private ApplicationEventPublisher publisher;
+    @Mock
+    private BotConfiguration botConfig;
+    @Mock
+    private AppConfiguration appConfig;
+
+    @InjectMocks
+    private BinanceProgressiveChunkedBuyOrderManager manager;
+
+    @Captor
+    private ArgumentCaptor<ErrorEvent> errorEventCaptor;
+
+    private final TradingSignal signal = new TradingSignal();
+    private final TickerData tickerData = new TickerData();
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        signal.setId("signal123");
+        signal.setSymbol("BTCUSDT");
+        signal.setEntryStart("110.0");
+        signal.setEntryEnd("90.0");
+
+        tickerData.setLastPrice("100.0");
+    }
+
+    @Test
+    void testShouldTriggerNextChunk_whenNotLastChunkAndPriceInRange_returnsTrue() throws Exception {
+        TradingSignal signal = new TradingSignal();
+        signal.setEntryStart("100");
+        signal.setEntryEnd("120");
+
+        ChunkOrder order = new ChunkOrder();
+        order.setTradingSignal(signal);
+        order.setSymbol("BTCUSDT");
+        order.setChunkIndex(1);
+        order.setTotalChunkCount(5);
+        order.setId("chunk-123");
+
+        TickerData tickerData = new TickerData();
+        tickerData.setLastPrice("110");
+        when(binanceApiManager.getTickerPrice24("BTCUSDT")).thenReturn(tickerData);
+
+        assertTrue(manager.shouldTriggerNextChunk(order));
+    }
+
+    @Test
+    void testShouldTriggerNextChunk_whenLastChunk_returnsFalse() {
+        ChunkOrder order = new ChunkOrder();
+        order.setChunkIndex(4);
+        order.setTotalChunkCount(5);
+        order.setId("chunk-123");
+
+        assertFalse(manager.shouldTriggerNextChunk(order));
+    }
+
+    @Test
+    void testShouldTriggerNextChunk_whenPriceOutOfRange_returnsFalse() throws Exception {
+        TradingSignal signal = new TradingSignal();
+        signal.setEntryStart("100");
+        signal.setEntryEnd("120");
+
+        ChunkOrder order = new ChunkOrder();
+        order.setTradingSignal(signal);
+        order.setSymbol("BTCUSDT");
+        order.setChunkIndex(1);
+        order.setTotalChunkCount(5);
+        order.setId("chunk-456");
+
+        TickerData ticker = new TickerData();
+        ticker.setLastPrice("130");
+        when(binanceApiManager.getTickerPrice24("BTCUSDT")).thenReturn(ticker);
+
+        assertFalse(manager.shouldTriggerNextChunk(order));
+    }
+
+    @Test
+    void testShouldRetryFailedChunk_whenPriceInRange_returnsTrue() throws Exception {
+        TradingSignal signal = new TradingSignal();
+        signal.setEntryStart("50");
+        signal.setEntryEnd("150");
+
+        ChunkOrder order = new ChunkOrder();
+        order.setSymbol("ETHUSDT");
+        order.setTradingSignal(signal);
+        order.setId("chunk-789");
+
+        TickerData ticker = new TickerData();
+        ticker.setLastPrice("100");
+        when(binanceApiManager.getTickerPrice24("ETHUSDT")).thenReturn(ticker);
+
+        assertTrue(manager.shouldRetryFailedChunk(order));
+    }
+
+    @Test
+    void testShouldRetryFailedChunk_whenExceptionOccurs_returnsFalse() throws Exception {
+        ChunkOrder order = new ChunkOrder();
+        order.setSymbol("FOO");
+        order.setTradingSignal(new TradingSignal());
+        order.setId("chunk-error");
+
+        when(binanceApiManager.getTickerPrice24("FOO")).thenThrow(new RuntimeException("API failed"));
+
+        assertFalse(manager.shouldRetryFailedChunk(order));
+    }
+
+    @Test
+    void testProcessExecutedProgressiveBuyChunks_triggersNextChunkOnlyWhenInRange() throws Exception {
+        ChunkOrder eligibleChunk = new ChunkOrder();
+        eligibleChunk.setChunkIndex(1);
+        eligibleChunk.setTotalChunkCount(3);
+        eligibleChunk.setSymbol("BTCUSDT");
+        eligibleChunk.setId("ok");
+        TradingSignal signal = new TradingSignal();
+        signal.setEntryStart("100");
+        signal.setEntryEnd("110");
+        eligibleChunk.setTradingSignal(signal);
+
+        TickerData ticker = new TickerData();
+        ticker.setLastPrice("105");
+        when(binanceApiManager.getTickerPrice24("BTCUSDT")).thenReturn(ticker);
+
+        when(botOrderService.getProgressiveChunksByStatusesAndDate(eq(List.of(OrderStatus.BUY_EXECUTED)), any()))
+                .thenReturn(List.of(eligibleChunk));
+        when(binanceHelper.getSearchDate()).thenReturn(new Date());
+
+        manager.processExecutedProgressiveBuyChunks();
+
+        verify(publisher).publishEvent(argThat(e -> e instanceof NewProgressiveChunkedSellOrderEvent));
+    }
+
+    @Test
+    void testProcessFailedProgressiveBuyChunks_triggersRetryOnlyWhenInRange() throws Exception {
+        ChunkOrder failedChunk = new ChunkOrder();
+        failedChunk.setSymbol("ADAUSDT");
+        failedChunk.setId("retry");
+        TradingSignal signal = new TradingSignal();
+        signal.setEntryStart("0.25");
+        signal.setEntryEnd("0.35");
+        failedChunk.setTradingSignal(signal);
+
+        TickerData ticker = new TickerData();
+        ticker.setLastPrice("0.30");
+        when(binanceApiManager.getTickerPrice24("ADAUSDT")).thenReturn(ticker);
+        when(binanceHelper.getSearchDate()).thenReturn(new Date());
+        when(botOrderService.getProgressiveChunksByStatusesAndDate(eq(List.of(OrderStatus.BUY_FAILED)), any()))
+                .thenReturn(List.of(failedChunk));
+
+        manager.processFailedProgressiveBuyChunks();
+
+        verify(publisher).publishEvent(argThat(e -> e instanceof NewProgressiveChunkedSellOrderEvent));
+    }
+
+    @Test
+    void testPlaceNextChunk_shouldSetExecutedStatusAndPublishEvents() throws Exception {
+        // Arrange
+        TradingSignal signal = new TradingSignal();
+        signal.setSymbol("BTCUSDT");
+        signal.setStopLoss("29000");
+        signal.setEntryStart("29500");
+        signal.setEntryEnd("30000");
+        signal.setTakeProfits(List.of("31000", "32000", "33000"));
+
+        double currentPrice = 29500;
+        int chunkIndex = 1;
+        int maxChunks = 3;
+
+        when(botConfig.getAmount()).thenReturn(900.0);
+
+        ArgumentCaptor<ChunkOrder> savedOrderCaptor = ArgumentCaptor.forClass(ChunkOrder.class);
+        when(botOrderService.saveChunkOrder(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // Act
+        manager.placeNextChunk(signal, currentPrice, chunkIndex, maxChunks);
+
+        // Assert
+        verify(binanceApiManager).newOrder(eq("BTCUSDT"), eq(currentPrice), anyDouble());
+        verify(botOrderService).saveChunkOrder(savedOrderCaptor.capture());
+        ChunkOrder savedOrder = savedOrderCaptor.getValue();
+
+        assertEquals(OrderStatus.BUY_EXECUTED, savedOrder.getStatus());
+        assertEquals("BTCUSDT", savedOrder.getSymbol());
+        assertEquals(chunkIndex, savedOrder.getChunkIndex());
+        assertEquals(maxChunks, savedOrder.getTotalChunkCount());
+        assertEquals(currentPrice, savedOrder.getEntryPoint());
+        assertEquals(33.0, savedOrder.getTakeProfitAllocation(), 0.0001);
+        assertEquals(1, savedOrder.getTakeProfitIndex());
+
+        verify(publisher).publishEvent(argThat(e -> e instanceof InfoEvent));
+        verify(publisher).publishEvent(argThat(e -> e instanceof NewProgressiveChunkedSellOrderEvent));
+    }
+
+    @Test
+    void testPlaceNextChunk_shouldSetFailedStatusAndPublishErrorEvent_onOrderFailure() throws Exception {
+        // Arrange
+        TradingSignal signal = new TradingSignal();
+        signal.setSymbol("BTCUSDT");
+        signal.setStopLoss("29000");
+        signal.setEntryStart("29500");
+        signal.setEntryEnd("30000");
+        signal.setTakeProfits(List.of("31000"));
+
+        double currentPrice = 29500;
+        int chunkIndex = 0;
+        int maxChunks = 1;
+
+        when(botConfig.getAmount()).thenReturn(500.0);
+        doThrow(new RuntimeException("Order failed")).when(binanceApiManager).newOrder(any(), anyDouble(), anyDouble());
+
+        when(botOrderService.saveChunkOrder(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // Act
+        manager.placeNextChunk(signal, currentPrice, chunkIndex, maxChunks);
+
+        // Assert
+        verify(botOrderService).saveChunkOrder(argThat(order ->
+                order.getStatus() == OrderStatus.BUY_FAILED &&
+                        order.getChunkIndex() == 0 &&
+                        order.getSymbol().equals("BTCUSDT")
+        ));
+
+        verify(publisher).publishEvent(argThat(e -> e instanceof ErrorEvent));
+        verify(publisher).publishEvent(argThat(e -> e instanceof NewProgressiveChunkedSellOrderEvent));
+    }
+
+    @Test
+    void shouldPlaceNextChunk_whenPriceInEntryRangeAndBullish_returnsTrue() {
+        TradingSignal signal = new TradingSignal();
+        signal.setEntryStart("1.10");
+        signal.setEntryEnd("1.00");
+
+        double currentPrice = 1.05;
+        List<KlineData> klines = Collections.emptyList();
+
+        when(binanceHelper.isShortTermBullish(klines)).thenReturn(true);
+
+        boolean result = manager.shouldPlaceNextChunk(signal, currentPrice, klines);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void shouldPlaceNextChunk_whenPriceNotInEntryRange_returnsFalse() {
+        TradingSignal signal = new TradingSignal();
+        signal.setEntryStart("1.10");
+        signal.setEntryEnd("1.00");
+
+        double currentPrice = 1.20;
+        List<KlineData> klines = Collections.emptyList();
+
+        when(binanceHelper.isShortTermBullish(klines)).thenReturn(true);
+
+        boolean result = manager.shouldPlaceNextChunk(signal, currentPrice, klines);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void shouldPlaceNextChunk_whenNotBullish_returnsFalse() {
+        TradingSignal signal = new TradingSignal();
+        signal.setEntryStart("1.10");
+        signal.setEntryEnd("1.00");
+
+        double currentPrice = 1.05;
+        List<KlineData> klines = Collections.emptyList();
+
+        when(binanceHelper.isShortTermBullish(klines)).thenReturn(false);
+
+        boolean result = manager.shouldPlaceNextChunk(signal, currentPrice, klines);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void shouldPlaceNextChunk_whenPriceOutOfBoundsAndNotBullish_returnsFalse() {
+        TradingSignal signal = new TradingSignal();
+        signal.setEntryStart("1.10");
+        signal.setEntryEnd("1.00");
+
+        double currentPrice = 0.95;
+        List<KlineData> klines = Collections.emptyList();
+
+        when(binanceHelper.isShortTermBullish(klines)).thenReturn(false);
+
+        boolean result = manager.shouldPlaceNextChunk(signal, currentPrice, klines);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void shouldTriggerNextChunk_returnsFalse_ifLastChunk() {
+        ChunkOrder chunk = new ChunkOrder();
+        chunk.setChunkIndex(2);
+        chunk.setTotalChunkCount(3);
+        chunk.setId("chunk-id");
+
+        boolean result = manager.shouldTriggerNextChunk(chunk);
+        assertFalse(result);
+    }
+
+    @Test
+    void shouldTriggerNextChunk_returnsTrue_ifInEntryZone() throws Exception {
+        ChunkOrder chunk = new ChunkOrder();
+        chunk.setChunkIndex(1);
+        chunk.setTotalChunkCount(3);
+        chunk.setSymbol("BTCUSDT");
+        TradingSignal signal = new TradingSignal();
+        signal.setEntryStart("90");
+        signal.setEntryEnd("110");
+        chunk.setTradingSignal(signal);
+
+        TickerData ticker = new TickerData();
+        ticker.setLastPrice("100");
+        when(binanceApiManager.getTickerPrice24("BTCUSDT")).thenReturn(ticker);
+
+        boolean result = manager.shouldTriggerNextChunk(chunk);
+        assertTrue(result);
+    }
+
+    @Test
+    void shouldRetryFailedChunk_returnsTrue_ifPriceInRange() throws Exception {
+        ChunkOrder chunk = new ChunkOrder();
+        chunk.setSymbol("BTCUSDT");
+        chunk.setId("chunk-1");
+
+        TradingSignal signal = new TradingSignal();
+        signal.setEntryStart("90");
+        signal.setEntryEnd("110");
+        chunk.setTradingSignal(signal);
+
+        TickerData ticker = new TickerData();
+        ticker.setLastPrice("95");
+        when(binanceApiManager.getTickerPrice24("BTCUSDT")).thenReturn(ticker);
+
+        boolean result = manager.shouldRetryFailedChunk(chunk);
+        assertTrue(result);
+    }
+
+    @Test
+    void shouldRetryFailedChunk_returnsFalse_ifException() throws Exception {
+        ChunkOrder chunk = new ChunkOrder();
+        chunk.setSymbol("INVALID");
+        chunk.setId("chunk-err");
+        TradingSignal signal = new TradingSignal();
+        signal.setEntryStart("90");
+        signal.setEntryEnd("110");
+        chunk.setTradingSignal(signal);
+
+        when(binanceApiManager.getTickerPrice24("INVALID")).thenThrow(new RuntimeException("Fail"));
+
+        boolean result = manager.shouldRetryFailedChunk(chunk);
+        assertFalse(result);
+    }
+
+    @Test
+    void shouldPlaceNextChunk_returnsTrue_ifShortTermBullishAndInRange() {
+        TradingSignal signal = new TradingSignal();
+        signal.setEntryStart("95");
+        signal.setEntryEnd("105");
+
+        List<KlineData> klines = List.of(new KlineData());
+        when(binanceHelper.isShortTermBullish(klines)).thenReturn(true);
+
+        boolean result = manager.shouldPlaceNextChunk(signal, 100, klines);
+        assertTrue(result);
+    }
+
+    @Test
+    void shouldPlaceNextChunk_returnsFalse_ifNotBullish() {
+        TradingSignal signal = new TradingSignal();
+        signal.setEntryStart("95");
+        signal.setEntryEnd("105");
+
+        List<KlineData> klines = List.of(new KlineData());
+        when(binanceHelper.isShortTermBullish(klines)).thenReturn(false);
+
+        boolean result = manager.shouldPlaceNextChunk(signal, 100, klines);
+        assertFalse(result);
+    }
+
+    @Test
+    void testHandleProgressiveChunkedBuy_shouldPlaceNextChunk() throws Exception {
+        NewProgressiveChunkedBuyOrderEvent event = new NewProgressiveChunkedBuyOrderEvent(this, signal, tickerData);
+
+        List<KlineData> klines = List.of(createKline(100000), createKline(110000));
+        when(appConfig.getMinQuoteVolume()).thenReturn(90000.0);
+        when(binanceApiManager.getListOfKlineData("BTCUSDT", IntervalType.FIVE_MINUTES)).thenReturn(klines);
+        when(binanceHelper.calculateDynamicChunkCount(anyDouble())).thenReturn(5);
+        when(botOrderService.getChunksBySignalAndStatuses(eq("signal123"), any())).thenReturn(List.of());
+        when(binanceHelper.isShortTermBullish(klines)).thenReturn(true);
+
+        manager.handleProgressiveChunkedBuy(event);
+
+        // Verify chunk is placed
+        verify(binanceHelper).calculateDynamicChunkCount(anyDouble());
+    }
+
+    @Test
+    void testHandleProgressiveChunkedBuy_shouldSkipDueToLowVolume() throws Exception {
+        NewProgressiveChunkedBuyOrderEvent event = new NewProgressiveChunkedBuyOrderEvent(this, signal, tickerData);
+
+        List<KlineData> klines = List.of(createKline(1000), createKline(1200));
+        when(appConfig.getMinQuoteVolume()).thenReturn(90000.0);
+        when(binanceApiManager.getListOfKlineData(any(), any())).thenReturn(klines);
+
+        manager.handleProgressiveChunkedBuy(event);
+
+        verify(binanceHelper, never()).calculateDynamicChunkCount(anyDouble());
+    }
+
+    @Test
+    void testHandleProgressiveChunkedBuy_shouldSkipWhenChunksFull() throws Exception {
+        NewProgressiveChunkedBuyOrderEvent event = new NewProgressiveChunkedBuyOrderEvent(this, signal, tickerData);
+
+        List<KlineData> klines = List.of(createKline(100000));
+        when(appConfig.getMinQuoteVolume()).thenReturn(50000.0);
+        when(binanceApiManager.getListOfKlineData(any(), any())).thenReturn(klines);
+        when(binanceHelper.calculateDynamicChunkCount(anyDouble())).thenReturn(2);
+        when(botOrderService.getChunksBySignalAndStatuses(eq("signal123"), any())).thenReturn(
+                List.of(new ChunkOrder(), new ChunkOrder()));
+
+        manager.handleProgressiveChunkedBuy(event);
+
+        verify(binanceHelper, never()).isShortTermBullish(any());
+    }
+
+    @Test
+    void testHandleProgressiveChunkedBuy_shouldTriggerErrorEvent() throws Exception {
+        NewProgressiveChunkedBuyOrderEvent event = new NewProgressiveChunkedBuyOrderEvent(this, signal, tickerData);
+
+        when(binanceApiManager.getListOfKlineData(any(), any())).thenThrow(new RuntimeException("API error"));
+
+        manager.handleProgressiveChunkedBuy(event);
+
+        verify(publisher).publishEvent(errorEventCaptor.capture());
+    }
+
+    private KlineData createKline(double quoteVolume) {
+        KlineData kline = new KlineData();
+        kline.setQuoteAssetVolume(quoteVolume);
+        return kline;
+    }
+}

--- a/src/test/java/com/ozgen/telegrambinancebot/manager/binance/BinanceProgressiveChunkedSellOrderManagerTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/manager/binance/BinanceProgressiveChunkedSellOrderManagerTest.java
@@ -1,0 +1,213 @@
+package com.ozgen.telegrambinancebot.manager.binance;
+
+import com.ozgen.telegrambinancebot.configuration.properties.BotConfiguration;
+import com.ozgen.telegrambinancebot.model.TradingStrategy;
+import com.ozgen.telegrambinancebot.model.binance.AssetBalance;
+import com.ozgen.telegrambinancebot.model.binance.TickerData;
+import com.ozgen.telegrambinancebot.model.bot.ChunkOrder;
+import com.ozgen.telegrambinancebot.model.bot.OrderStatus;
+import com.ozgen.telegrambinancebot.model.events.ErrorEvent;
+import com.ozgen.telegrambinancebot.model.events.InfoEvent;
+import com.ozgen.telegrambinancebot.model.events.NewProgressiveChunkedSellOrderEvent;
+import com.ozgen.telegrambinancebot.model.telegram.TradingSignal;
+import com.ozgen.telegrambinancebot.service.BotOrderService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.*;
+
+class BinanceProgressiveChunkedSellOrderManagerTest {
+
+    @Mock
+    private BinanceApiManager binanceApiManager;
+
+    @Mock
+    private BotOrderService botOrderService;
+
+    @Mock
+    private ApplicationEventPublisher publisher;
+
+    @Mock
+    private BotConfiguration botConfiguration;
+
+    @Mock
+    private BinanceHelper binanceHelper;
+
+    @InjectMocks
+    private BinanceProgressiveChunkedSellOrderManager manager;
+
+    private ChunkOrder chunk;
+    private TradingSignal signal;
+    private TickerData ticker;
+
+    @BeforeEach
+    void setup() throws Exception {
+        MockitoAnnotations.openMocks(this);
+
+        signal = new TradingSignal();
+        signal.setStopLoss("90");
+        signal.setStrategy(TradingStrategy.DEFAULT);
+        signal.setTakeProfits(List.of("110", "120", "130"));
+
+        chunk = new ChunkOrder();
+        chunk.setSymbol("BTCUSDT");
+        chunk.setBuyPrice(100.0);
+        chunk.setBuyCoinAmount(10.0);
+        chunk.setTakeProfitIndex(0);
+        chunk.setTradingSignal(signal);
+        chunk.setId("chunk123");
+
+        ticker = new TickerData();
+        ticker.setLastPrice("115");
+
+        when(binanceApiManager.getTickerPrice24("BTCUSDT")).thenReturn(ticker);
+        when(botConfiguration.getProfitPercentage()).thenReturn(5.0);
+    }
+
+    @Test
+    void testOnNewSellProgressiveChunkOrderEvent_shouldDelegateToProcessChunkOrder() {
+        // Arrange
+        ChunkOrder mockChunkOrder = new ChunkOrder();
+        mockChunkOrder.setId("chunk123");
+
+        NewProgressiveChunkedSellOrderEvent event = new NewProgressiveChunkedSellOrderEvent(this, mockChunkOrder);
+
+        BinanceProgressiveChunkedSellOrderManager spyManager = Mockito.spy(manager);
+
+        // Act
+        spyManager.onNewSellProgressiveChunkOrderEvent(event);
+
+        // Assert
+        verify(spyManager).processChunkOrder(mockChunkOrder);
+    }
+
+
+    @Test
+    void testProcessChunkOrder_shouldSell() {
+        AssetBalance balance = new AssetBalance();
+        balance.setAsset("BTC");
+        balance.setFree("10");
+        when(binanceHelper.getUserAssets()).thenReturn(List.of(balance));
+        when(binanceHelper.calculateSellAmount(any(), any())).thenReturn(10.0);
+        when(botOrderService.getProgressiveChunksByStatusesAndDate(any(), any())).thenReturn(List.of(chunk));
+
+        manager.processSellChunkOrders();
+
+        verify(botOrderService, atLeastOnce()).saveChunkOrder(any());
+        verify(botOrderService).getProgressiveChunksByStatusesAndDate(any(), any());
+        verify(publisher).publishEvent(any(InfoEvent.class));
+    }
+
+    @Test
+    void testProcessChunkOrder_shouldRetryDueToLowPriceWithSellLater() {
+        ticker.setLastPrice("95");
+        signal.setStrategy(TradingStrategy.SELL_LATER);
+        when(botOrderService.getProgressiveChunksByStatusesAndDate(any(), any())).thenReturn(List.of(chunk));
+
+        manager.processSellChunkOrders();
+
+        verify(botOrderService, atLeastOnce()).saveChunkOrder(any());
+        verify(botOrderService).getProgressiveChunksByStatusesAndDate(any(), any());
+        assertEquals(OrderStatus.SELL_PENDING_RETRY, chunk.getStatus());
+        verify(publisher, never()).publishEvent(isA(InfoEvent.class));
+    }
+
+    @Test
+    void testProcessChunkOrder_shouldRetryDueToLowPriceDefault() {
+        ticker.setLastPrice("95");
+        signal.setStrategy(TradingStrategy.DEFAULT);
+        AssetBalance balance = new AssetBalance();
+        balance.setAsset("BTC");
+        balance.setFree("10");
+        when(binanceHelper.getUserAssets()).thenReturn(List.of(balance));
+        when(binanceHelper.calculateSellAmount(any(), any())).thenReturn(10.0);
+        when(botOrderService.getProgressiveChunksByStatusesAndDate(any(), any())).thenReturn(List.of(chunk));
+
+        manager.processSellChunkOrders();
+
+        verify(botOrderService, atLeastOnce()).saveChunkOrder(any());
+        verify(botOrderService).getProgressiveChunksByStatusesAndDate(any(), any());
+        assertEquals(OrderStatus.SELL_EXECUTED, chunk.getStatus());
+        verify(publisher).publishEvent(isA(InfoEvent.class));
+    }
+
+    @Test
+    void testProcessChunkOrder_shouldFail() throws Exception {
+        when(binanceApiManager.getTickerPrice24("BTCUSDT"))
+                .thenThrow(new RuntimeException("Price fetch failed"));
+        when(botOrderService.getProgressiveChunksByStatusesAndDate(any(), any())).thenReturn(List.of(chunk));
+
+        manager.processSellChunkOrders();
+
+        verify(botOrderService, atLeastOnce()).saveChunkOrder(any());
+        verify(publisher).publishEvent(any(ErrorEvent.class));
+    }
+
+    @Test
+    void testRetryPendingChunks_shouldTriggerEvent() throws Exception {
+        chunk.setBuyPrice(100);
+        ticker.setLastPrice("105");
+        when(botOrderService.getBuyChunksByStatus(OrderStatus.SELL_PENDING_RETRY)).thenReturn(List.of(chunk));
+        when(binanceApiManager.getTickerPrice24("BTCUSDT")).thenReturn(ticker);
+
+        manager.retryPendingChunks();
+
+        verify(publisher).publishEvent(any(NewProgressiveChunkedSellOrderEvent.class));
+    }
+
+    @Test
+    void testRetryPendingChunks_shouldSkipEvent() {
+        chunk.setBuyPrice(110);
+        ticker.setLastPrice("100");
+        when(botOrderService.getBuyChunksByStatus(OrderStatus.SELL_PENDING_RETRY)).thenReturn(List.of(chunk));
+
+        manager.retryPendingChunks();
+
+        verify(publisher, never()).publishEvent(any(NewProgressiveChunkedSellOrderEvent.class));
+    }
+
+    @Test
+    void testRetryPendingChunks_shouldHandleException() throws Exception {
+        when(botOrderService.getBuyChunksByStatus(OrderStatus.SELL_PENDING_RETRY)).thenReturn(List.of(chunk));
+        when(binanceApiManager.getTickerPrice24("BTCUSDT")).thenThrow(new RuntimeException("fail"));
+
+        manager.retryPendingChunks();
+
+        verify(publisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void testProcessSellChunkOrders_shouldIterateAll() {
+        ChunkOrder c1 = new ChunkOrder();
+        c1.setSymbol("BTCUSDT");
+        c1.setId("1");
+        c1.setBuyPrice(100.0);
+        c1.setTradingSignal(signal);
+
+        ChunkOrder c2 = new ChunkOrder();
+        c2.setSymbol("BTCUSDT");
+        c2.setId("2");
+        c2.setBuyPrice(100.0);
+        c2.setTradingSignal(signal);
+
+        when(binanceHelper.getSearchDate()).thenReturn(new Date());
+        when(botOrderService.getProgressiveChunksByStatusesAndDate(any(), any())).thenReturn(List.of(c1, c2));
+        BinanceProgressiveChunkedSellOrderManager spyManager = spy(manager);
+
+        spyManager.processSellChunkOrders();
+
+        verify(spyManager).processChunkOrder(c1);
+        verify(spyManager).processChunkOrder(c2);
+    }
+}

--- a/src/test/java/com/ozgen/telegrambinancebot/manager/binance/BinanceTradingSignalManagerTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/manager/binance/BinanceTradingSignalManagerTest.java
@@ -6,7 +6,7 @@ import com.ozgen.telegrambinancebot.model.events.ErrorEvent;
 import com.ozgen.telegrambinancebot.model.events.IncomingChunkedTradingSignalEvent;
 import com.ozgen.telegrambinancebot.model.events.IncomingTradingSignalEvent;
 import com.ozgen.telegrambinancebot.model.events.NewBuyOrderEvent;
-import com.ozgen.telegrambinancebot.model.events.NewChunkedBuyExecutionEvent;
+import com.ozgen.telegrambinancebot.model.events.NewChunkedBuyOrderEvent;
 import com.ozgen.telegrambinancebot.model.telegram.TradingSignal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -146,10 +146,10 @@ public class BinanceTradingSignalManagerTest {
 
         // Assert
         verify(binanceApiManager).getTickerPrice24(SYMBOL);
-        ArgumentCaptor<NewChunkedBuyExecutionEvent> eventCaptor = ArgumentCaptor.forClass(NewChunkedBuyExecutionEvent.class);
+        ArgumentCaptor<NewChunkedBuyOrderEvent> eventCaptor = ArgumentCaptor.forClass(NewChunkedBuyOrderEvent.class);
         verify(publisher).publishEvent(eventCaptor.capture());
 
-        NewChunkedBuyExecutionEvent publishedEvent = eventCaptor.getValue();
+        NewChunkedBuyOrderEvent publishedEvent = eventCaptor.getValue();
         assertEquals(tradingSignal, publishedEvent.getTradingSignal());
         assertEquals(tickerData, publishedEvent.getTickerData());
     }
@@ -167,7 +167,7 @@ public class BinanceTradingSignalManagerTest {
 
         verify(binanceApiManager).getTickerPrice24(SYMBOL);
         verify(publisher).publishEvent(any(ErrorEvent.class));
-        verify(publisher, never()).publishEvent(isA(NewChunkedBuyExecutionEvent.class));
+        verify(publisher, never()).publishEvent(isA(NewChunkedBuyOrderEvent.class));
     }
 
     @Test
@@ -186,6 +186,6 @@ public class BinanceTradingSignalManagerTest {
 
         // Assert
         verify(binanceApiManager).getTickerPrice24(SYMBOL);
-        verify(publisher, never()).publishEvent(isA(NewChunkedBuyExecutionEvent.class));
+        verify(publisher, never()).publishEvent(isA(NewChunkedBuyOrderEvent.class));
     }
 }

--- a/src/test/java/com/ozgen/telegrambinancebot/manager/bot/TradeSignalManagerTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/manager/bot/TradeSignalManagerTest.java
@@ -3,6 +3,7 @@ package com.ozgen.telegrambinancebot.manager.bot;
 
 import com.ozgen.telegrambinancebot.configuration.properties.ScheduleConfiguration;
 import com.ozgen.telegrambinancebot.model.events.IncomingChunkedTradingSignalEvent;
+import com.ozgen.telegrambinancebot.model.events.IncomingProgressiveChunkedTradingSignalEvent;
 import com.ozgen.telegrambinancebot.model.events.IncomingTradingSignalEvent;
 import com.ozgen.telegrambinancebot.model.telegram.TradingSignal;
 import com.ozgen.telegrambinancebot.service.TradingSignalService;
@@ -19,9 +20,7 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class TradeSignalManagerTest {
 
@@ -107,4 +106,22 @@ public class TradeSignalManagerTest {
         verify(publisher).publishEvent(any(IncomingChunkedTradingSignalEvent.class));
     }
 
+    @Test
+    public void testProcessInitTradingSignalsForProgressiveChunkOrders() {
+        // Arrange
+        TradingSignal mockSignal = new TradingSignal();
+        mockSignal.setId(UUID.randomUUID().toString());
+
+        when(scheduleConfiguration.getMonthBefore()).thenReturn(1);
+
+        when(tradingSignalService.getAllTradingSignalsAfterDateAndIsProcessInForPrChunkOrders(any(), anyList()))
+                .thenReturn(List.of(mockSignal));
+
+        // Act
+        tradeSignalManager.processInitTradingSignalsForProgressiveChunkOrders();
+
+        // Assert
+        verify(tradingSignalService).getAllTradingSignalsAfterDateAndIsProcessInForPrChunkOrders(any(), anyList());
+        verify(publisher).publishEvent(any(IncomingProgressiveChunkedTradingSignalEvent.class));
+    }
 }

--- a/src/test/java/com/ozgen/telegrambinancebot/manager/telegram/TelegramMessageManagerTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/manager/telegram/TelegramMessageManagerTest.java
@@ -45,7 +45,7 @@ public class TelegramMessageManagerTest {
     void testParseTelegramMessage_withValidSignal() {
         // Arrange
         String message = TestData.TRADING_SIGNAL;
-        when(appConfiguration.getExecutionStrategy()).thenReturn(ExecutionStrategy.DEFAULT);
+        when(appConfiguration.getStrategy()).thenReturn(ExecutionStrategy.DEFAULT);
         when(tradingSignalService.saveTradingSignal(any(TradingSignal.class)))
                 .thenAnswer((Answer<TradingSignal>) invocation -> (TradingSignal) invocation.getArguments()[0]);
 
@@ -64,7 +64,7 @@ public class TelegramMessageManagerTest {
     void testParseTelegramMessage_withValidSignalAndChunkStrategy() {
         // Arrange
         String message = TestData.TRADING_SIGNAL;
-        when(appConfiguration.getExecutionStrategy()).thenReturn(ExecutionStrategy.CHUNKED);
+        when(appConfiguration.getStrategy()).thenReturn(ExecutionStrategy.CHUNKED);
         when(tradingSignalService.saveTradingSignal(any(TradingSignal.class)))
                 .thenAnswer((Answer<TradingSignal>) invocation -> (TradingSignal) invocation.getArguments()[0]);
 

--- a/src/test/java/com/ozgen/telegrambinancebot/scheduling/binance/BinanceProgressiveChunkOrderRetryToSellSchedulerTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/scheduling/binance/BinanceProgressiveChunkOrderRetryToSellSchedulerTest.java
@@ -1,0 +1,27 @@
+package com.ozgen.telegrambinancebot.scheduling.binance;
+
+import com.ozgen.telegrambinancebot.manager.binance.BinanceProgressiveChunkedSellOrderManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class BinanceProgressiveChunkOrderRetryToSellSchedulerTest {
+
+    private BinanceProgressiveChunkedSellOrderManager sellOrderManager;
+    private BinanceProgressiveChunkOrderRetryToSellScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        sellOrderManager = Mockito.mock(BinanceProgressiveChunkedSellOrderManager.class);
+        scheduler = new BinanceProgressiveChunkOrderRetryToSellScheduler(sellOrderManager);
+    }
+
+    @Test
+    void shouldRetryPendingChunksWhenScheduled() {
+        // when
+        scheduler.retryPendingChunks();
+
+        // then
+        Mockito.verify(sellOrderManager).retryPendingChunks();
+    }
+}

--- a/src/test/java/com/ozgen/telegrambinancebot/scheduling/bot/BuyErrorProgressiveChunkOrdersSchedulerTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/scheduling/bot/BuyErrorProgressiveChunkOrdersSchedulerTest.java
@@ -1,0 +1,27 @@
+package com.ozgen.telegrambinancebot.scheduling.bot;
+
+import com.ozgen.telegrambinancebot.manager.binance.BinanceProgressiveChunkedBuyOrderManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class BuyErrorProgressiveChunkOrdersSchedulerTest {
+
+    private BinanceProgressiveChunkedBuyOrderManager buyOrderManager;
+    private BuyErrorProgressiveChunkOrdersScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        buyOrderManager = Mockito.mock(BinanceProgressiveChunkedBuyOrderManager.class);
+        scheduler = new BuyErrorProgressiveChunkOrdersScheduler(buyOrderManager);
+    }
+
+    @Test
+    void shouldProcessFailedProgressiveBuyChunksWhenScheduled() {
+        // when
+        scheduler.processFailedProgressiveBuyChunks();
+
+        // then
+        Mockito.verify(buyOrderManager).processFailedProgressiveBuyChunks();
+    }
+}

--- a/src/test/java/com/ozgen/telegrambinancebot/scheduling/bot/ProgressiveChunkBuyOrdersSchedulerTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/scheduling/bot/ProgressiveChunkBuyOrdersSchedulerTest.java
@@ -1,0 +1,27 @@
+package com.ozgen.telegrambinancebot.scheduling.bot;
+
+import com.ozgen.telegrambinancebot.manager.binance.BinanceProgressiveChunkedBuyOrderManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ProgressiveChunkBuyOrdersSchedulerTest {
+
+    private BinanceProgressiveChunkedBuyOrderManager buyOrderManager;
+    private ProgressiveChunkBuyOrdersScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        buyOrderManager = Mockito.mock(BinanceProgressiveChunkedBuyOrderManager.class);
+        scheduler = new ProgressiveChunkBuyOrdersScheduler(buyOrderManager);
+    }
+
+    @Test
+    void shouldProcessExecutedProgressiveBuyChunksWhenScheduled() {
+        // when
+        scheduler.processSellLaterOrders();
+
+        // then
+        Mockito.verify(buyOrderManager).processExecutedProgressiveBuyChunks();
+    }
+}

--- a/src/test/java/com/ozgen/telegrambinancebot/scheduling/bot/SellErrorProgressiveChunkOrdersSchedulerTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/scheduling/bot/SellErrorProgressiveChunkOrdersSchedulerTest.java
@@ -1,0 +1,27 @@
+package com.ozgen.telegrambinancebot.scheduling.bot;
+
+import com.ozgen.telegrambinancebot.manager.binance.BinanceProgressiveChunkedSellOrderManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class SellErrorProgressiveChunkOrdersSchedulerTest {
+
+    private BinanceProgressiveChunkedSellOrderManager sellOrderManager;
+    private SellErrorProgressiveChunkOrdersScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        sellOrderManager = Mockito.mock(BinanceProgressiveChunkedSellOrderManager.class);
+        scheduler = new SellErrorProgressiveChunkOrdersScheduler(sellOrderManager);
+    }
+
+    @Test
+    void shouldProcessSellChunkOrdersWhenScheduled() {
+        // when
+        scheduler.processSellChunkOrders();
+
+        // then
+        Mockito.verify(sellOrderManager).processSellChunkOrders();
+    }
+}

--- a/src/test/java/com/ozgen/telegrambinancebot/scheduling/bot/TradingSignalSchedulerTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/scheduling/bot/TradingSignalSchedulerTest.java
@@ -40,4 +40,14 @@ public class TradingSignalSchedulerTest {
         verify(this.tradeSignalManager)
                 .processInitTradingSignalsForChunkOrders();
     }
+
+    @Test
+    public void testProcessInitTradingSignalsForProgressiveChunkOrders() {
+        // when
+        this.tradingSignalScheduler.processInitTradingSignalsForProgressiveChunkOrders();
+
+        // then
+        verify(this.tradeSignalManager)
+                .processInitTradingSignalsForProgressiveChunkOrders();
+    }
 }

--- a/src/test/java/com/ozgen/telegrambinancebot/service/BotOrderServiceTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/service/BotOrderServiceTest.java
@@ -339,4 +339,74 @@ public class BotOrderServiceTest {
         assertTrue(result.isEmpty());
         verify(chunkOrderRepository).findAllByCreatedAtAfterAndStatusInAndTradingSignal_ExecutionStrategy(date, statuses, ExecutionStrategy.CHUNKED);
     }
+
+    @Test
+    public void testGetBuyProgressiveChunksByStatusesAndDate_Success() {
+        // Arrange
+        List<OrderStatus> statuses = List.of(OrderStatus.BUY_EXECUTED);
+        Date date = new Date();
+        List<ChunkOrder> expectedChunks = List.of(new ChunkOrder());
+        when(chunkOrderRepository.findAllByCreatedAtAfterAndStatusInAndTradingSignal_ExecutionStrategy(date, statuses, ExecutionStrategy.CHUNKED_PROGRESSIVE))
+                .thenReturn(expectedChunks);
+
+        // Act
+        List<ChunkOrder> result = botOrderService.getProgressiveChunksByStatusesAndDate(statuses, date);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(expectedChunks, result);
+        verify(chunkOrderRepository).findAllByCreatedAtAfterAndStatusInAndTradingSignal_ExecutionStrategy(date, statuses, ExecutionStrategy.CHUNKED_PROGRESSIVE);
+    }
+
+    @Test
+    public void testGetBuyProgressiveChunksByStatusesAndDate_Exception() {
+        // Arrange
+        List<OrderStatus> statuses = List.of(OrderStatus.SELL_FAILED);
+        Date date = new Date();
+        when(chunkOrderRepository.findAllByCreatedAtAfterAndStatusInAndTradingSignal_ExecutionStrategy(date, statuses, ExecutionStrategy.CHUNKED_PROGRESSIVE))
+                .thenThrow(new RuntimeException("Simulated DB error"));
+
+        // Act
+        List<ChunkOrder> result = botOrderService.getProgressiveChunksByStatusesAndDate(statuses, date);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(chunkOrderRepository).findAllByCreatedAtAfterAndStatusInAndTradingSignal_ExecutionStrategy(date, statuses, ExecutionStrategy.CHUNKED_PROGRESSIVE);
+    }
+
+    @Test
+    public void testGetChunksBySignalAndStatuses_Success() {
+        // Arrange
+        String signalId = "test-signal-id";
+        List<OrderStatus> statuses = List.of(OrderStatus.SELL_FAILED, OrderStatus.SELL_PENDING_RETRY);
+        List<ChunkOrder> expectedChunks = List.of(new ChunkOrder());
+        when(chunkOrderRepository.findAllByTradingSignalIdAndStatusIn(signalId, statuses))
+                .thenReturn(expectedChunks);
+
+        // Act
+        List<ChunkOrder> result = botOrderService.getChunksBySignalAndStatuses(signalId, statuses);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(expectedChunks, result);
+        verify(chunkOrderRepository).findAllByTradingSignalIdAndStatusIn(signalId, statuses);
+    }
+
+    @Test
+    public void testGetChunksBySignalAndStatuses_Exception() {
+        // Arrange
+        String signalId = "faulty-signal-id";
+        List<OrderStatus> statuses = List.of(OrderStatus.BUY_FAILED);
+        when(chunkOrderRepository.findAllByTradingSignalIdAndStatusIn(signalId, statuses))
+                .thenThrow(new RuntimeException("Simulated error"));
+
+        // Act
+        List<ChunkOrder> result = botOrderService.getChunksBySignalAndStatuses(signalId, statuses);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(chunkOrderRepository).findAllByTradingSignalIdAndStatusIn(signalId, statuses);
+    }
 }

--- a/src/test/java/com/ozgen/telegrambinancebot/service/BotOrderServiceTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/service/BotOrderServiceTest.java
@@ -5,6 +5,7 @@ import com.ozgen.telegrambinancebot.adapters.repository.BuyOrderRepository;
 import com.ozgen.telegrambinancebot.adapters.repository.ChunkOrderRepository;
 import com.ozgen.telegrambinancebot.adapters.repository.SellOrderRepository;
 import com.ozgen.telegrambinancebot.adapters.repository.TradingSignalRepository;
+import com.ozgen.telegrambinancebot.model.ExecutionStrategy;
 import com.ozgen.telegrambinancebot.model.bot.BuyOrder;
 import com.ozgen.telegrambinancebot.model.bot.ChunkOrder;
 import com.ozgen.telegrambinancebot.model.bot.OrderStatus;
@@ -312,7 +313,7 @@ public class BotOrderServiceTest {
         List<OrderStatus> statuses = List.of(OrderStatus.SELL_PENDING_RETRY, OrderStatus.BUY_EXECUTED);
         Date date = new Date();
         List<ChunkOrder> expectedChunks = List.of(new ChunkOrder());
-        when(chunkOrderRepository.findAllByCreatedAtAfterAndStatusIn(date, statuses)).thenReturn(expectedChunks);
+        when(chunkOrderRepository.findAllByCreatedAtAfterAndStatusInAndTradingSignal_ExecutionStrategy(date, statuses, ExecutionStrategy.CHUNKED)).thenReturn(expectedChunks);
 
         // Act
         List<ChunkOrder> result = botOrderService.getBuyChunksByStatusesAndDate(statuses, date);
@@ -320,7 +321,7 @@ public class BotOrderServiceTest {
         // Assert
         assertNotNull(result);
         assertEquals(expectedChunks, result);
-        verify(chunkOrderRepository).findAllByCreatedAtAfterAndStatusIn(date, statuses);
+        verify(chunkOrderRepository).findAllByCreatedAtAfterAndStatusInAndTradingSignal_ExecutionStrategy(date, statuses, ExecutionStrategy.CHUNKED);
     }
 
     @Test
@@ -328,7 +329,7 @@ public class BotOrderServiceTest {
         // Arrange
         List<OrderStatus> statuses = List.of(OrderStatus.SELL_FAILED);
         Date date = new Date();
-        when(chunkOrderRepository.findAllByCreatedAtAfterAndStatusIn(date, statuses)).thenThrow(new RuntimeException("DB error"));
+        when(chunkOrderRepository.findAllByCreatedAtAfterAndStatusInAndTradingSignal_ExecutionStrategy(date, statuses, ExecutionStrategy.CHUNKED)).thenThrow(new RuntimeException("DB error"));
 
         // Act
         List<ChunkOrder> result = botOrderService.getBuyChunksByStatusesAndDate(statuses, date);
@@ -336,6 +337,6 @@ public class BotOrderServiceTest {
         // Assert
         assertNotNull(result);
         assertTrue(result.isEmpty());
-        verify(chunkOrderRepository).findAllByCreatedAtAfterAndStatusIn(date, statuses);
+        verify(chunkOrderRepository).findAllByCreatedAtAfterAndStatusInAndTradingSignal_ExecutionStrategy(date, statuses, ExecutionStrategy.CHUNKED);
     }
 }

--- a/src/test/java/com/ozgen/telegrambinancebot/service/TradingSignalServiceTest.java
+++ b/src/test/java/com/ozgen/telegrambinancebot/service/TradingSignalServiceTest.java
@@ -205,5 +205,26 @@ public class TradingSignalServiceTest {
         verify(tradingSignalRepository).findAllByCreatedAtAfterAndIsProcessedInAndStrategyInAndExecutionStrategy(
                 date, processStatuses, expectedStrategies, ExecutionStrategy.CHUNKED);
     }
+
+    @Test
+    public void testGetAllTradingSignalsAfterDateAndIsProcessInForPrChunkOrders_Success() {
+        // Arrange
+        Date date = new Date();
+        List<Integer> processStatuses = List.of(0, 1);
+        List<TradingStrategy> strategies = List.of(TradingStrategy.DEFAULT, TradingStrategy.SELL_LATER);
+        List<TradingSignal> expectedSignals = List.of(new TradingSignal());
+
+        when(tradingSignalRepository.findAllByCreatedAtAfterAndIsProcessedInAndStrategyInAndExecutionStrategy(
+                date, processStatuses, strategies, ExecutionStrategy.CHUNKED_PROGRESSIVE))
+                .thenReturn(expectedSignals);
+
+        // Act
+        List<TradingSignal> result = tradingSignalService.getAllTradingSignalsAfterDateAndIsProcessInForPrChunkOrders(date, processStatuses);
+
+        // Assert
+        assertEquals(expectedSignals, result);
+        verify(tradingSignalRepository).findAllByCreatedAtAfterAndIsProcessedInAndStrategyInAndExecutionStrategy(
+                date, processStatuses, strategies, ExecutionStrategy.CHUNKED_PROGRESSIVE);
+    }
 }
 


### PR DESCRIPTION


This PR enhances the `CHUNKED_PROGRESSIVE` execution strategy with advanced signal handling based on user feedback. The following capabilities have been added:

## New Features

* **Multiple Entry Point Support**
  Parses entry ranges and splits investment margin accordingly for each entry point.

* **Dynamic Leverage Calculation**
  Computes leverage per chunk using:

  ```
  leverage = entryPrice / (entryPrice - stopLoss)
  ```

* **Margin Allocation per Chunk**
  Distributes total investment across all calculated chunks based on quote volume and entry range.

* **Multiple Take-Profit Levels**
  Assigns a TP target (TP1, TP2, ...) to each chunk based on the index and rotates if needed.


https://github.com/ozgen/binance-telegram-bot/issues/68